### PR TITLE
General improvements of the code, with new features and options

### DIFF
--- a/Steve.h
+++ b/Steve.h
@@ -508,17 +508,20 @@ RVec<Int_t> Probe_isMatched(const RVec<std::pair<int,int>> &TPPairs,
                             const RVec<Int_t> &target_extraIdx, 
                             const RVec<Int_t> &target_passProbeCondition)
 {
-    RVec<Int_t> res(TPPairs.size(), 0);
+    //RVec<Int_t> res(TPPairs.size(), 0);
+    RVec<Int_t> res(probe_extraIdx.size(), 0);
     // std::cout << "TPPairs.size() = " << TPPairs.size() << std::endl;
     // std::cout << "probe_extraIdx.size() = " << probe_extraIdx.size() << std::endl;
     // std::cout << "target_extraIdx.size() = " << target_extraIdx.size()  << std::endl;
     // std::cout << "target_passProbeCondition.size() = " << target_passProbeCondition.size()  << std::endl;
     for (unsigned int i = 0; i < TPPairs.size(); i++) {
+        int probeId = TPPairs.at(i).second;
         for (unsigned int j = 0; j < target_extraIdx.size(); j++) {
             // std::cout << "Probe id = " << TPPairs.at(i).second << std::endl;
-            if ( (probe_extraIdx[TPPairs.at(i).second] == target_extraIdx[j]) && target_passProbeCondition[j] ) {
+            if ( (probe_extraIdx[probeId] == target_extraIdx[j]) && target_passProbeCondition[j] ) {
                 //if ( probe_extraIdx[TPPairs.at(i).second] == target_extraIdx[j]) {
-                res[i] = 1;
+                // res[i] = 1;
+                res[probeId] = 1;
                 // std::cout << "Target match with index = " << j << std::endl;
                 // std::cout << "Target extraIdx = " << target_extraIdx[j] << std::endl;
                 // std::cout << "Probe extraIdx = " << probe_extraIdx[TPPairs.at(i).second] << std::endl;
@@ -535,6 +538,7 @@ RVec<Int_t> Probe_isMatched(const RVec<std::pair<int,int>> &TPPairs,
 }
 
 // particular case of previous function, could be exchanged for that
+// actually this function is probably wrong since the returned size is not the one of the MergedStandAloneMuon_extraIdx collection
 RVec<Int_t> Probe_isGlobal(const RVec<std::pair<int,int>> &TPPairs, 
                            const RVec<Int_t> &MergedStandAloneMuon_extraIdx, 
                            const RVec<Int_t> &Muon_standaloneExtraIdx, 

--- a/Steve.h
+++ b/Steve.h
@@ -114,71 +114,6 @@ RVec<Float_t> selfDeltaR(const RVec<Float_t>& eta1, const RVec<Float_t>& phi1, c
     return res;
 }
 
-RVec<Int_t> CreateProbes_Muon(RVec<Float_t> &Muon_pt, RVec<Float_t> &Muon_standalonePt,
-			      RVec<Float_t> &Muon_eta,RVec<Float_t> &Muon_phi, 
-			      RVec<Float_t> &Muon_standaloneEta, 
-			      RVec<Float_t> &Muon_standalonePhi, 
-			      RVec<Int_t> &Muon_charge, RVec<Bool_t> &Muon_mediumId, 
-			      RVec<Float_t> &Muon_dxybs,RVec<Bool_t> &Muon_isGlobal)
-{
-  RVec<Int_t> Probe_Muons;
-  for(int i=0;i<Muon_pt.size();i++){
-    if(Muon_pt.at(i) < 15 || Muon_standalonePt.at(i) < 15 || abs(Muon_eta.at(i)) > 2.4 || 
-       !Muon_isGlobal.at(i) || deltaR(Muon_eta.at(i),Muon_phi.at(i),
-	      			      Muon_standaloneEta.at(i),Muon_standalonePhi.at(i)) > 0.3) 
-      continue;
-    //Probe probe_muon;
-    //probe_muon.pt = Muon_pt.at(i);
-    //probe_muon.eta = Muon_eta.at(i);
-    //probe_muon.phi = Muon_phi.at(i);
-    //probe_muon.charge = Muon_charge.at(i);
-    //probe_muon.original_index = i;
-    Probe_Muons.push_back(i);
-  }
-  return Probe_Muons;
-}
-
-RVec<Int_t> CreateProbes_Track(RVec<Float_t> &Track_pt, RVec<Float_t> &Track_eta,
-                               RVec<Float_t> &Track_phi,RVec<Int_t> &Track_charge, 
-                               RVec<Int_t> &Track_trackOriginalAlgo)
-{
-
-  RVec<Int_t> Probe_Tracks;
-  for(int i=0;i<Track_pt.size();i++){
-    if(Track_pt.at(i) < 15. || abs(Track_eta.at(i)) > 2.4 || 
-       Track_trackOriginalAlgo.at(i) == 13 || Track_trackOriginalAlgo.at(i) == 14) continue;
-    //Probe probe_track;
-    //probe_track.pt = Track_pt.at(i);
-    //probe_track.eta = Track_eta.at(i);
-    //probe_track.phi = Track_phi.at(i);
-    //probe_track.charge = Track_charge.at(i);
-    //probe_track.original_index = i;
-    Probe_Tracks.push_back(i);
-  }
-  return Probe_Tracks;
-
-}
-
-RVec<Int_t> CreateProbes_MergedStandMuons(RVec<Float_t> &MergedStandAloneMuon_pt, 
-					  RVec<Float_t> &MergedStandAloneMuon_eta, 
-					  RVec<Float_t> &MergeStandAloneMuon_phi)
-{
-
-  RVec<Int_t> Probe_Stand;
-  for(int i=0;i<MergedStandAloneMuon_pt.size();i++){
-    if(MergedStandAloneMuon_pt.at(i) < 15.) continue;
-    if(MergedStandAloneMuon_eta.at(i) > 2.4) continue;
-    //Probe probe_track;
-    //probe_track.pt = Track_pt.at(i);
-    //probe_track.eta = Track_eta.at(i);
-    //probe_track.phi = Track_phi.at(i);
-    //probe_track.charge = Track_charge.at(i);
-    //probe_track.original_index = i;
-    Probe_Stand.push_back(i);
-  }
-  return Probe_Stand;
-
-}
 
 RVec<std::pair<int,int>> CreateTPPair(const RVec<Int_t> &Tag_muons, 
                                       const RVec<Int_t> &Probe_Candidates,
@@ -559,8 +494,8 @@ RVec<Int_t> Probe_isGlobal(const RVec<std::pair<int,int>> &TPPairs,
                            const RVec<Int_t> &Muon_passProbeCondition)
 {
     RVec<Int_t> isGlobal(TPPairs.size(), 0);
-    for (auto i=0U; i<TPPairs.size(); i++) {
-        for (unsigned int j=0; j < Muon_standaloneExtraIdx.size(); j++) {
+    for (unsigned int i = 0; i < TPPairs.size(); i++) {
+        for (unsigned int j = 0; j < Muon_standaloneExtraIdx.size(); j++) {
             if ( (MergedStandAloneMuon_extraIdx[TPPairs.at(i).second] == Muon_standaloneExtraIdx[j]) && Muon_passProbeCondition[j]) {
                 isGlobal[i] = 1;
                 break;
@@ -585,7 +520,7 @@ RVec<Int_t> Probe_isGlobal_checkExtraIdxTagInnerTrack(const RVec<std::pair<int,i
         int tag_index = TPPair.first;
         int probe_index = TPPair.second;
         int condition = 0;
-        for (unsigned int j=0; j < Muon_standaloneExtraIdx.size(); j++) {
+        for (unsigned int j = 0; j < Muon_standaloneExtraIdx.size(); j++) {
             if ( (MergedStandAloneMuon_extraIdx[probe_index] == Muon_standaloneExtraIdx[j]) && Muon_passProbeCondition[j]) {
                 // only accept cases where the matched global muon does not coincide with the tag 
                 if (Tag_innerTrackExtraIdx[tag_index] != Muon_innerTrackExtraIdx[j]) {
@@ -604,7 +539,7 @@ RVec<Int_t> getMergedStandAloneMuon_MuonIdx(const RVec<Int_t> &MergedStandAloneM
                                             const RVec<Int_t> &Muon_standaloneExtraIdx)
 {
     RVec<Int_t> res(MergedStandAloneMuon_extraIdx.size(), -1); // initialize to invalid index
-    for (unsigned int i =0; i < MergedStandAloneMuon_extraIdx.size(); i++) {
+    for (unsigned int i = 0; i < MergedStandAloneMuon_extraIdx.size(); i++) {
         for (unsigned int j = 0; j < Muon_standaloneExtraIdx.size(); j++) {
             if ( MergedStandAloneMuon_extraIdx[i] == Muon_standaloneExtraIdx[j] ) {
                 res[i] = j;
@@ -652,9 +587,28 @@ RVec<Float_t> getMergedStandAloneMuon_matchedObjectVar(const RVec<Int_t> &Merged
     // the assumption is that this function will be used only for MergedStandAloneMuon elements for which the corresponding matched object was already checked to exist
     RVec<Float_t> res(MergedStandAloneMuon_matchedObjIdx.size(), invalidValue); // initialize to default value for invalid indices
     int index = -1;
-    for (unsigned int i =0; i < MergedStandAloneMuon_matchedObjIdx.size(); i++) {
+    for (unsigned int i = 0; i < MergedStandAloneMuon_matchedObjIdx.size(); i++) {
         index = MergedStandAloneMuon_matchedObjIdx[i];
         if (index >= 0) res[i] = matchedObj_var[index];
+    }
+    return res;
+
+}
+
+// return a collection equipollent to global muons, containing the number of valid hits for the associated standalone track
+// similar to what getMergedStandAloneMuon_matchedObjectVar does for standalone muons
+template <typename T>
+RVec<T> getGlobalMuon_MergedStandAloneMuonVar(const RVec<Int_t> &Muon_standaloneExtraIdx,
+                                              const RVec<Int_t> &MergedStandAloneMuon_extraIdx,
+                                              const RVec<T> &MergedStandAloneMuon_variable)
+{
+    RVec<T> res(Muon_standaloneExtraIdx.size(), -1); // initialize to invalid index
+    for (unsigned int ig = 0; ig < Muon_standaloneExtraIdx.size(); ig++) {
+        for (unsigned int isa = 0; isa < MergedStandAloneMuon_extraIdx.size(); isa++) {
+            if ( Muon_standaloneExtraIdx[ig] == MergedStandAloneMuon_extraIdx[isa]) {
+                res[ig] = MergedStandAloneMuon_variable[isa];
+            }
+        }
     }
     return res;
 

--- a/Steve.h
+++ b/Steve.h
@@ -577,15 +577,15 @@ RVec<Int_t> getMergedStandAloneMuon_highestPtTrackIdxWithinDR(const RVec<Float_t
 
 }
 
-
-RVec<Float_t> getMergedStandAloneMuon_matchedObjectVar(const RVec<Int_t> &MergedStandAloneMuon_matchedObjIdx, 
-                                                       const RVec<Float_t> &matchedObj_var,
-                                                       const Float_t invalidValue = -99.9)
+template <typename T>
+RVec<T> getMergedStandAloneMuon_matchedObjectVar(const RVec<Int_t> &MergedStandAloneMuon_matchedObjIdx, 
+                                                 const RVec<T> &matchedObj_var,
+                                                 const T invalidValue = -99)
 {
     // MergedStandAloneMuon_matchedObjIdx can be created using getMergedStandAloneMuon_MuonIdx if the target collection is Muon,
     // or getMergedStandAloneMuon_highestPtTrackIdxWithinDR if it is a track
     // the assumption is that this function will be used only for MergedStandAloneMuon elements for which the corresponding matched object was already checked to exist
-    RVec<Float_t> res(MergedStandAloneMuon_matchedObjIdx.size(), invalidValue); // initialize to default value for invalid indices
+    RVec<T> res(MergedStandAloneMuon_matchedObjIdx.size(), invalidValue); // initialize to default value for invalid indices
     int index = -1;
     for (unsigned int i = 0; i < MergedStandAloneMuon_matchedObjIdx.size(); i++) {
         index = MergedStandAloneMuon_matchedObjIdx[i];
@@ -595,7 +595,7 @@ RVec<Float_t> getMergedStandAloneMuon_matchedObjectVar(const RVec<Int_t> &Merged
 
 }
 
-// return a collection equipollent to global muons, containing the number of valid hits for the associated standalone track
+// return a collection equipollent to global muons, containing the variable for the associated standalone track
 // similar to what getMergedStandAloneMuon_matchedObjectVar does for standalone muons
 template <typename T>
 RVec<T> getGlobalMuon_MergedStandAloneMuonVar(const RVec<Int_t> &Muon_standaloneExtraIdx,

--- a/Steve.h
+++ b/Steve.h
@@ -426,6 +426,20 @@ RVec<Float_t> getTPmass(RVec<std::pair<int,int>> TPPairs,
     
 }
 
+RVec<Float_t> getTPabsDiffZ(RVec<std::pair<int,int>> TPPairs,
+                            RVec<Float_t> &tag_Z, RVec<Float_t> &probe_Z)
+{
+    RVec<Float_t> TPAbsDiffZ;
+    for (int i = 0; i < TPPairs.size(); i++){
+        std::pair<int,int> TPPair = TPPairs.at(i);
+        int tag_index = TPPair.first;
+        int probe_index = TPPair.second;        
+        TPAbsDiffZ.push_back( std::fabs(tag_Z[tag_index] - probe_Z[probe_index]) );
+    }
+    return TPAbsDiffZ;
+    
+}
+
 template <typename T>
 RVec<T> getVariables(RVec<std::pair<int,int>> TPPairs,
                      RVec<T>  &Cand_variable, 

--- a/Steve.h
+++ b/Steve.h
@@ -76,6 +76,14 @@ double _get_vertexPileupWeight(const Float_t& vertexZ, const Float_t& nTrueInt, 
 
 ////=====================================================================================
 
+template <typename T>
+int printRvec(const RVec<T>  &vec, const int id = 0)
+{
+    std::cout << id << ": size = " << vec.size() << std::endl;
+    return 1;
+}
+
+////=====================================================================================
 
 float deltaPhi(float phi1, float phi2)
 {                                                        
@@ -203,6 +211,7 @@ RVec<std::pair<int,int>> CreateTPPair(const RVec<Int_t> &Tag_muons,
         }
 
     }
+    // std::cout << "Found " << TP_pairs.size() << " tag-probe pairs" << std::endl;
     return TP_pairs;
 
 }
@@ -430,6 +439,9 @@ RVec<T> getVariables(RVec<std::pair<int,int>> TPPairs,
         else if (option==2) variable = Cand_variable.at(TPPair.second);
         Variables[i] = variable;
     }
+    // if (TPPairs.size()) {
+    //     std::cout << "in getVariables(), size = " << Variables.size() << std::endl;
+    // }
     return Variables;
 }
 
@@ -491,6 +503,38 @@ RVec<Bool_t> isOS(RVec<std::pair<int,int>> TPPairs, RVec<Int_t> Muon_charge,
 }
 
 
+RVec<Int_t> Probe_isMatched(const RVec<std::pair<int,int>> &TPPairs, 
+                            const RVec<Int_t> &probe_extraIdx, 
+                            const RVec<Int_t> &target_extraIdx, 
+                            const RVec<Int_t> &target_passProbeCondition)
+{
+    RVec<Int_t> res(TPPairs.size(), 0);
+    // std::cout << "TPPairs.size() = " << TPPairs.size() << std::endl;
+    // std::cout << "probe_extraIdx.size() = " << probe_extraIdx.size() << std::endl;
+    // std::cout << "target_extraIdx.size() = " << target_extraIdx.size()  << std::endl;
+    // std::cout << "target_passProbeCondition.size() = " << target_passProbeCondition.size()  << std::endl;
+    for (unsigned int i = 0; i < TPPairs.size(); i++) {
+        for (unsigned int j = 0; j < target_extraIdx.size(); j++) {
+            // std::cout << "Probe id = " << TPPairs.at(i).second << std::endl;
+            if ( (probe_extraIdx[TPPairs.at(i).second] == target_extraIdx[j]) && target_passProbeCondition[j] ) {
+                //if ( probe_extraIdx[TPPairs.at(i).second] == target_extraIdx[j]) {
+                res[i] = 1;
+                // std::cout << "Target match with index = " << j << std::endl;
+                // std::cout << "Target extraIdx = " << target_extraIdx[j] << std::endl;
+                // std::cout << "Probe extraIdx = " << probe_extraIdx[TPPairs.at(i).second] << std::endl;
+                break;
+            }
+        }
+    }
+    // printRvec(res, 1);
+    // for (unsigned int i = 0; i < res.size(); i++) {
+    //     std::cout << i << "=" << res[i] << "   ";
+    // }
+    // std::cout << " " << std::endl;
+    return res;
+}
+
+// particular case of previous function, could be exchanged for that
 RVec<Int_t> Probe_isGlobal(const RVec<std::pair<int,int>> &TPPairs, 
                            const RVec<Int_t> &MergedStandAloneMuon_extraIdx, 
                            const RVec<Int_t> &Muon_standaloneExtraIdx, 
@@ -725,11 +769,4 @@ void saveHistogramsGen(ROOT::RDF::RResultPtr<THnT<double> > histo_pass, ROOT::RD
     delete histo_norm;
     f_out.Close();
   }
-}
-
-template <typename T>
-int printRvec(const RVec<T>  &vec, const int id = 0)
-{
-    std::cout << id << ": size = " << vec.size() << std::endl;
-    return 1;
 }

--- a/Steve.py
+++ b/Steve.py
@@ -365,7 +365,7 @@ elif (args.efficiency == 2):
         #binning_pt = array('d',[15., 30., 45., 60., 80.])
         #binning_pt = array('d',[15., 25., 35., 45., 55., 65., 80.])
         #binning_pt = array('d',[24., 65.])
-        binning_pt = array('d',[25., 35., 45., 55., 65.])
+        binning_pt = array('d',[24., 35., 45., 55., 65.])
         #binning_pt = array('d',[(15.0 + i*1.0) for i in range(66) ])
         
         # Here we are using the muon variables to calulate the mass for the passing probes for tracking efficiency

--- a/Steve.py
+++ b/Steve.py
@@ -334,7 +334,7 @@ elif (args.efficiency == 2):
         d = d.Define("All_TPmass","getTPmass(All_TPPairs, Tag_pt, Tag_eta, Tag_phi, MergedStandAloneMuon_pt, MergedStandAloneMuon_eta, MergedStandAloneMuon_phi)")
 
         massLow  =  50
-        massHigh = 130
+        massHigh = 150
         binning_mass = array('d',[massLow + i for i in range(int(1+massHigh-massLow))])
         massCut = f"All_TPmass > {massLow} && All_TPmass < {massHigh}"
         d = d.Define("TPPairs", f"All_TPPairs[{massCut}]")
@@ -452,8 +452,8 @@ elif args.efficiency != 7:
     d = d.Define("passCondition_IDIP", "Muon_mediumId && abs(Muon_dxybs) < 0.05")
     d = d.Define("passCondition_Trig", "isTriggeredMuon")
     d = d.Define("passCondition_Iso",  "Muon_pfRelIso04_all < 0.15")
-    #d = d.Define("passCondition_Iso",  "Muon_pfRelIso03_all < 0.15")
-    #d = d.Define("passCondition_Iso",  "Muon_pfRelIso03_chg < 0.15")
+    #d = d.Define("passCondition_Iso",  "Muon_pfRelIso03_all < 0.10")
+    #d = d.Define("passCondition_Iso",  "Muon_pfRelIso03_chg < 0.05")
     
     # For IDIP
     if (args.efficiency == 3):

--- a/Steve.py
+++ b/Steve.py
@@ -357,7 +357,7 @@ elif (args.efficiency == 2):
         d = d.Define("Muon_forTracking", "Muon_isGlobal && Muon_pt > 10 && Muon_standalonePt > 15 && selfDeltaR(Muon_eta, Muon_phi, Muon_standaloneEta, Muon_standalonePhi) < 0.3")
         # check Muon exists with proper criteria and matching extraIdx with the standalone muon 
         d = d.Define("passCondition_tracking",
-                     "Probe_isGlobal(TPPairs, MergedStandAloneMuon_extraIdx, Muon_standaloneExtraIdx, Muon_forTracking)")
+                     "Probe_isMatched(TPPairs, MergedStandAloneMuon_extraIdx, Muon_standaloneExtraIdx, Muon_forTracking)")
         #d = d.Define("passCondition_tracking",
         #             "Probe_isGlobal_checkExtraIdxTagInnerTrack(TPPairs, MergedStandAloneMuon_extraIdx, Muon_standaloneExtraIdx, Muon_forTracking, Tag_inExtraIdx, Muon_innerTrackExtraIdx)")
         
@@ -713,8 +713,10 @@ else:
 
     ## IMPORTANT: define only the specific condition to be passed, not with the && of previous steps (although in principle it is the same as long as that one is already applied)
     ##            also, these are based on the initial Muon collection, with no precooked filtering
-    d = d.Define("vetoMuons", "Muon_pt > 10 && abs(Muon_eta) < 2.4 && (Muon_isGlobal || Muon_isTracker) && Muon_looseId && abs(Muon_dxybs) < 0.05")
-    d = d.Define("passCondition_veto", "coll1coll2DR(Track_eta, Track_phi, Muon_eta[vetoMuons], Muon_phi[vetoMuons]) < 0.1")
+    d = d.Define("vetoMuons", "Muon_pt > 10 && abs(Muon_eta) < 2.4 && (Muon_isGlobal || Muon_isTracker) && Muon_innerTrackOriginalAlgo != 13 && Muon_innerTrackOriginalAlgo != 14 && Muon_looseId && abs(Muon_dxybs) < 0.05 && Muon_highPurity")
+    #d = d.Define("passCondition_veto", "coll1coll2DR(Track_eta, Track_phi, Muon_eta[vetoMuons], Muon_phi[vetoMuons]) < 0.1")
+    d = d.Define("passCondition_veto",
+                 "Probe_isMatched(TPPairs, Track_extraIdx, Muon_innerTrackExtraIdx, vetoMuons)")
 
     # define condition for passing probes
     d = d.Define("passCondition", "getVariables(TPPairs, passCondition_veto, 2)")

--- a/Steve.py
+++ b/Steve.py
@@ -82,6 +82,12 @@ parser.add_argument("-d","--isData", help="Pass 0 for MC, 1 for Data, default is
 parser.add_argument("-tpt","--tagPt", help="Minimum pt to select tag muons",
                     type=float, default=25.)
 
+parser.add_argument("-tiso","--tagIso", help="Isolation threshold to select tag muons",
+                    type=float, default=0.15)
+
+parser.add_argument(        "--standaloneValidHits", help="Minimum number of valid hits for the standalone track (>= this value)",
+                    type=int, default=1)
+
 parser.add_argument("-c","--charge", help="Make efficiencies for a specific charge of the probe (-1/1 for positive negative, 0 for inclusive)",
                     type=int, default=0, choices=[-1, 0, 1])
 
@@ -136,7 +142,7 @@ for root, dirnames, filenames in os.walk(args.input_path):
 
 if args.charge and args.efficiency in [2]:
     print("")
-    print("   WARNING: charge splitting not implemented for tracking efficiency. I will derive charge inclusive efficiencies")
+    print("   WARNING: charge splitting for tracking efficiency is implemented using the tag muon (with the other charge)")
     print("")
 
 
@@ -176,7 +182,7 @@ GENXBINS.push_back(ROOT.std.vector('double')(binning_eta))
 GENXBINS.push_back(ROOT.std.vector('double')(binning_charge))
 GENXBINS.push_back(ROOT.std.vector('double')(binning_u))
 
-minStandaloneNumberOfValidHits = 10
+minStandaloneNumberOfValidHits = args.standaloneValidHits
 
 ##General Cuts
 d = d.Filter("HLT_IsoMu24 || HLT_IsoTkMu24","HLT Cut")
@@ -241,7 +247,7 @@ TagAntiChargeCut = ""
 if args.efficiency == 2 and args.charge:
     TagAntiChargeCut = " && Tag_charge < 0" if args.charge > 0 else " && Tag_charge > 0" # note that we swap charge 
 # now define the tag muon (Muon_isGlobal might not be necessary, but shouldn't hurt really)
-d = d.Define("Tag_Muons", f"Muon_pt > {args.tagPt} && abs(Muon_eta) < 2.4 && Muon_pfRelIso04_all < 0.15 && abs(Muon_dxybs) < 0.05 && Muon_mediumId && Muon_isGlobal && isTriggeredMuon && isGenMatchedMuon {TagAntiChargeCut}")
+d = d.Define("Tag_Muons", f"Muon_pt > {args.tagPt} && abs(Muon_eta) < 2.4 && Muon_pfRelIso04_all < {args.tagIso} && abs(Muon_dxybs) < 0.05 && Muon_mediumId && Muon_isGlobal && isTriggeredMuon && isGenMatchedMuon {TagAntiChargeCut}")
 
 if (args.genLevelEfficiency):
     d = d.Define("zero","0").Define("one","1") # is this really needed? Can't we just pass 1 or 0 in the functions where we need it?

--- a/Steve_tracker.py
+++ b/Steve_tracker.py
@@ -264,10 +264,17 @@ if(args.efficiency == 1):
         # condition for passing probes
         d = d.Define("trackerMuons", "Muon_pt > 10 && Muon_isTracker && Muon_innerTrackOriginalAlgo != 13 && Muon_innerTrackOriginalAlgo != 14 && Muon_highPurity")
         # check Muon exists with proper criteria and matching extraIdx with the track 
+
+        # # TEST 1 (it runs fine with coll1coll2DR instead of Probe_isMatched, but I don't know if the result would be the same)
+        # d = d.Define("passCondition_reco",
+        #              #"coll1coll2DR(Track_eta, Track_phi, Muon_eta[trackerMuons], Muon_phi[trackerMuons]) < 0.1")
+        #              "Probe_isMatched(TPPairs, Track_extraIdx, Muon_innerTrackExtraIdx, trackerMuons)")
+        # d = d.Define("passCondition", "getVariables(TPPairs, passCondition_reco, 2)")
+        # d = d.Define("failCondition", "!passCondition")
+        
         d = d.Define("passCondition_reco",
                      #"coll1coll2DR(Track_eta, Track_phi, Muon_eta[trackerMuons], Muon_phi[trackerMuons]) < 0.1")
                      "Probe_isMatched(TPPairs, Track_extraIdx, Muon_innerTrackExtraIdx, trackerMuons)")
-
         d = d.Define("passCondition", "getVariables(TPPairs, passCondition_reco, 2)")
         d = d.Define("failCondition", "!passCondition")
 

--- a/runAll.py
+++ b/runAll.py
@@ -71,7 +71,7 @@ if __name__ == "__main__":
     parser.add_argument('-x','--exclude', default=None, nargs='*', type=int, choices=list(workingPoints.keys()),
                         help='Default runs all working points, but can choose to skip some if needed')
     parser.add_argument('-wpc','--workinPointsByCharge', default=["trigger"], nargs='*', type=str, choices=list(workingPoints.values()),
-                        help='Default runs all working points, but can choose only some if needed')
+                        help='These steps will be made charge dependent')
     parser.add_argument("-trk", "--trackerMuons", action="store_true",
                         help="Use tracker muons and a different executable")
     #parser.add_argument('-exe', '--executable', default="Steve.py", type=str, choices=["Steve.py", "Steve_tracker.py"],

--- a/runAll.py
+++ b/runAll.py
@@ -68,6 +68,8 @@ if __name__ == "__main__":
                         help='Default runs all working points, but can choose only some if needed')
     parser.add_argument('-wpc','--workinPointsByCharge', default=["trigger"], nargs='*', type=str, choices=list(workingPoints.values()),
                         help='Default runs all working points, but can choose only some if needed')
+    parser.add_argument('-exe', '--executable', default="Steve.py", type=str, choices=["Steve.py", "Steve_tracker.py"],
+                        help='Choose script to run')
     args = parser.parse_args()
 
     outdir = args.outdir
@@ -111,7 +113,7 @@ if __name__ == "__main__":
                     step += "plus" if ch == 1 else "minus"
                 outfile = f"{outdir}tnp_{step}_{xrun}_{postfix}.root"
                 outfiles.append(outfile)
-                cmd = f"python Steve.py -i {inpath} -o {outfile} -d {isdata} -e {wp} -c {ch}"
+                cmd = f"python {args.executable} -i {inpath} -o {outfile} -d {isdata} -e {wp} -c {ch}"
                 if args.noVertexPileupWeight:
                     cmd += " -nw"
                 if args.noOppositeCharge:

--- a/runAll.py
+++ b/runAll.py
@@ -12,7 +12,9 @@
 # because at the moment they are always the same, it is the file name that distinguishes the working points
 #
 # use -d to test the command, without running them automatically
-
+#
+# typical default command for all steps
+# python runAll.py -i input -o output --noOppositeChargeTracking
 
 import os, re, copy, math, array
 

--- a/runAll.py
+++ b/runAll.py
@@ -104,14 +104,16 @@ if __name__ == "__main__":
         for wp in workingPoints.keys():            
             if args.steps and wp not in args.steps:
                 continue
-            if wp == 2 and args.noOppositeChargeTracking:
-                postfix = postfix.replace("oscharge1", "oscharge0")
             charges = [-1, 1] if workingPoints[wp] in args.workinPointsByCharge else [0]
             for ch in charges:
                 step = workingPoints[wp]
                 if ch:
                     step += "plus" if ch == 1 else "minus"
-                outfile = f"{outdir}tnp_{step}_{xrun}_{postfix}.root"
+                if wp == 2 and args.noOppositeChargeTracking:
+                    postfixTracking = postfix.replace("oscharge1", "oscharge0")
+                    outfile = f"{outdir}tnp_{step}_{xrun}_{postfixTracking}.root"
+                else:
+                    outfile = f"{outdir}tnp_{step}_{xrun}_{postfix}.root"
                 outfiles.append(outfile)
                 cmd = f"python {args.executable} -i {inpath} -o {outfile} -d {isdata} -e {wp} -c {ch}"
                 if args.noVertexPileupWeight:

--- a/runAll.py
+++ b/runAll.py
@@ -66,6 +66,8 @@ if __name__ == "__main__":
                                 help="Don't require opposite charges between tag and probe for tracking")
     parser.add_argument('-s','--steps', default=None, nargs='*', type=int, choices=list(workingPoints.keys()),
                         help='Default runs all working points, but can choose only some if needed')
+    parser.add_argument('-x','--exclude', default=None, nargs='*', type=int, choices=list(workingPoints.keys()),
+                        help='Default runs all working points, but can choose to skip some if needed')
     parser.add_argument('-wpc','--workinPointsByCharge', default=["trigger"], nargs='*', type=str, choices=list(workingPoints.values()),
                         help='Default runs all working points, but can choose only some if needed')
     parser.add_argument('-exe', '--executable', default="Steve.py", type=str, choices=["Steve.py", "Steve_tracker.py"],
@@ -102,6 +104,8 @@ if __name__ == "__main__":
         isdata = 0 if xrun == "mc" else 1
         inpath = indir + (inputdir_data if isdata else inputdir_mc)
         for wp in workingPoints.keys():            
+            if args.exclude and wp in args.exclude:
+                continue
             if args.steps and wp not in args.steps:
                 continue
             charges = [-1, 1] if workingPoints[wp] in args.workinPointsByCharge else [0]

--- a/runAll.py
+++ b/runAll.py
@@ -76,6 +76,12 @@ if __name__ == "__main__":
                         help="Use tracker muons and a different executable")
     parser.add_argument("-p","--eventParity", help="Select events with given parity for statistical tests, -1/1 for odd/even events, 0 for all (default)",
                         type=int, nargs='+', default=[0], choices=[-1, 0, 1])
+    parser.add_argument("-tpt","--tagPt", help="Minimum pt to select tag muons",
+                        type=float, default=25.)
+    parser.add_argument("-tiso","--tagIso", help="Isolation threshold to select tag muons",
+                        type=float, default=0.15)
+    parser.add_argument(        "--standaloneValidHits", help="Minimum number of valid hits for the standalone track (>= this value)",
+                        type=int, default=1)
     #parser.add_argument('-exe', '--executable', default="Steve.py", type=str, choices=["Steve.py", "Steve_tracker.py"],
     #                    help='Choose script to run')
     args = parser.parse_args()
@@ -107,6 +113,8 @@ if __name__ == "__main__":
     postfix = "vertexWeights{v}_oscharge{c}".format(v="0" if args.noVertexPileupWeight  else "1",
                                                     c="0" if args.noOppositeCharge      else "1")
 
+    commonOption = f" --tagPt {args.tagPt} --tagIso {args.tagIso} --standaloneValidHits {args.standaloneValidHits}"
+
     for xrun in toRun:
 
         isdata = 0 if xrun == "mc" else 1
@@ -131,6 +139,7 @@ if __name__ == "__main__":
                         outfile = f"{outdir}tnp_{step}_{xrun}_{postfix}.root"
                     outfiles.append(outfile)
                     cmd = f"python {executable} -i {inpath} -o {outfile} -d {isdata} -e {wp} -c {ch} -p {parity}"
+                    cmd += commonOption
                     if args.noVertexPileupWeight:
                         cmd += " -nw"
                     if args.noOppositeCharge:

--- a/runAll.py
+++ b/runAll.py
@@ -70,8 +70,10 @@ if __name__ == "__main__":
                         help='Default runs all working points, but can choose to skip some if needed')
     parser.add_argument('-wpc','--workinPointsByCharge', default=["trigger"], nargs='*', type=str, choices=list(workingPoints.values()),
                         help='Default runs all working points, but can choose only some if needed')
-    parser.add_argument('-exe', '--executable', default="Steve.py", type=str, choices=["Steve.py", "Steve_tracker.py"],
-                        help='Choose script to run')
+    parser.add_argument("-trk", "--trackerMuons", action="store_true",
+                        help="Use tracker muons and a different executable")
+    #parser.add_argument('-exe', '--executable', default="Steve.py", type=str, choices=["Steve.py", "Steve_tracker.py"],
+    #                    help='Choose script to run')
     args = parser.parse_args()
 
     outdir = args.outdir
@@ -81,6 +83,8 @@ if __name__ == "__main__":
     if not indir.endswith("/"):
         indir += "/"
 
+    executable = "Steve_tracker.py" if args.trackerMuons else "Steve.py"
+        
     if not os.path.exists(outdir):
         print(f"Creating folder {outdir}")
         safeSystem(f"mkdir -p {outdir}", dryRun=False)
@@ -119,7 +123,7 @@ if __name__ == "__main__":
                 else:
                     outfile = f"{outdir}tnp_{step}_{xrun}_{postfix}.root"
                 outfiles.append(outfile)
-                cmd = f"python {args.executable} -i {inpath} -o {outfile} -d {isdata} -e {wp} -c {ch}"
+                cmd = f"python {executable} -i {inpath} -o {outfile} -d {isdata} -e {wp} -c {ch}"
                 if args.noVertexPileupWeight:
                     cmd += " -nw"
                 if args.noOppositeCharge:


### PR DESCRIPTION
This PR introduces some new features in Steve, as well as new options to customise the making of efficiencies according to some of our more frequent needs (e.g. to test charge dependence, or split events into odd/even for statistical tests of uncertainties, or also changing the tag selection).
It also removes some obsolete functions or lines.
This is the version of the code that was used to derive our currently used efficiencies in Wremnants, namely those in [0]

[0] https://mciprian.web.cern.ch/mciprian/WMassAnalysis/TnP/egm_tnp_analysis/results_globalMuons_ntuplesXYZ_1orMoreNvalidHitsStandalone/

TODO (with low priority)
- define common options between Steve.py and runAll.py in some other python script to be imported (for clarity, since most options are just meant to be directly propagated from runAll to Steve)
- define a logging system (e.g. as in Wremnants for the main analysis) to improve the logging, also by adding colours for warnings which the user should not miss
- ensure consistency with Steve_tracker.py, which has been left behind (we don't plan to use only tracker muons any longer, but might be worth keeping it updated)

All these features/improvements can be easily implemented by copying code from Wremnants