### PR TITLE
GenMatch options to properly run on backgrounds

### DIFF
--- a/Steve.h
+++ b/Steve.h
@@ -48,6 +48,7 @@ void initializeVertexPileupWeights(const std::string& _filename_vertexPileupWeig
                   << _filename_vertexPileupWeights << "! Aborting" << std::endl;
         exit(EXIT_FAILURE);
       }
+      // std::cout << "Era:" << era << std::endl;
       histptr->SetDirectory(0);
       hVertexPileupWeights[id] = *dynamic_cast<TH2D*>(histptr);
       id++;
@@ -66,6 +67,8 @@ void initializeVertexPileupWeights(const std::string& _filename_vertexPileupWeig
 
   }
   _file_vertexPileupWeights.Close();
+  
+  std::cout << "INFO >>> Histograms correctly initialized with vertex-pileup weights" << std::endl;
   
 }
 

--- a/Steve.h
+++ b/Steve.h
@@ -396,7 +396,7 @@ RVec<Bool_t> hasGenMatch(RVec<Float_t> &Gen_eta, RVec<Float_t> &Gen_phi,
             mcmatch_tmp_dr = tmpDR;
         } 
     }
-    if (mcmatch_tmp_dr < coneDR) matchMC = true;
+    if ( (coneDR>0 && mcmatch_tmp_dr<coneDR) || (coneDR<0 && mcmatch_tmp_dr>-coneDR) ) matchMC = true;
     isGenMatched.push_back(matchMC);
   }
   return isGenMatched;
@@ -417,7 +417,7 @@ RVec<Int_t> GenMatchedIdx(RVec<Float_t> &GenPart_eta,RVec<Float_t> &GenPart_phi,
                 matchIdx=iGen;
             } 
         }
-        if (mcmatch_tmp_dr < coneDR) isGenMatched[iCand] = matchIdx;
+        if ( (coneDR>0 && mcmatch_tmp_dr<coneDR) || (coneDR<0 && mcmatch_tmp_dr>-coneDR) ) isGenMatched[iCand] = matchIdx;
         else isGenMatched[iCand] = -1;
     }
     return isGenMatched;

--- a/Steve.h
+++ b/Steve.h
@@ -331,6 +331,7 @@ RVec<Bool_t> hasTriggerMatch2018(RVec<Float_t> &Muon_eta, RVec<Float_t> &Muon_ph
   return TriggerMatch;
 }
 
+/*
 RVec<Bool_t> hasGenMatch(RVec<Int_t> &GenPart_pdgId, RVec<Int_t> &GenPart_status,
 			 RVec<Int_t> &GenPart_statusFlags, RVec<Float_t> &GenPart_eta,
 			 RVec<Float_t> &GenPart_phi, RVec<Float_t> &Cand_eta, 
@@ -359,7 +360,6 @@ RVec<Bool_t> hasGenMatch(RVec<Int_t> &GenPart_pdgId, RVec<Int_t> &GenPart_status
   return isGenMatched;
 }
 
-
 RVec<Int_t> GenMatchedIdx(RVec<Int_t> &GenPart_pdgId, RVec<Int_t> &GenPart_status,RVec<Int_t> &GenPart_statusFlags,RVec<Float_t> &GenPart_eta,RVec<Float_t> &GenPart_phi,RVec<Float_t> &Cand_eta, RVec<Float_t> &Cand_phi, const float coneDR = 0.1){
   RVec<Int_t> isGenMatched;  
   for(int iCand=0;iCand<Cand_eta.size();iCand++){
@@ -381,6 +381,55 @@ RVec<Int_t> GenMatchedIdx(RVec<Int_t> &GenPart_pdgId, RVec<Int_t> &GenPart_statu
   }
   return isGenMatched;
 }
+*/
+
+// USE THE FOLLOWING TWO FUNCTIONS
+/*
+// use directly the collection of gen muons define in the apporpriate way
+RVec<Bool_t> hasGenMatch(RVec<Float_t> &Gen_eta, RVec<Float_t> &Gen_phi,
+                         RVec<Float_t> &Cand_eta, RVec<Float_t> &Cand_phi,
+                         const float coneDR = 0.1)
+{
+	RVec<Bool_t> isGenMatched;  
+	float tmpDR = 0.0; // utility variable filled below everytime
+	for(int iCand=0;iCand<Cand_eta.size();iCand++) {
+		bool matchMC = false;   
+		float mcmatch_tmp_dr = 999.;
+		for(unsigned int iGen=0; iGen<Gen_eta.size(); iGen++) {
+			tmpDR = deltaR(Cand_eta[iCand], Cand_phi[iCand], Gen_eta[iGen], Gen_phi[iGen]);
+			if (tmpDR < mcmatch_tmp_dr) {
+				mcmatch_tmp_dr = tmpDR;
+			} 
+		}
+		if (mcmatch_tmp_dr < coneDR) matchMC = true;
+		isGenMatched.push_back(matchMC);
+	}
+	return isGenMatched;
+}
+
+
+RVec<Int_t> GenMatchedIdx(RVec<Float_t> &GenPart_eta, RVec<Float_t> &GenPart_phi,
+						  RVec<Float_t> &Cand_eta, RVec<Float_t> &Cand_phi, 
+						  const float coneDR = 0.1)
+{
+	RVec<Int_t> isGenMatched(Cand_eta.size(), -1); //  fill with proper size and initialize to -1  
+	float tmpDR = 0.0; // utility variable filled below everytime
+	for(int iCand=0;iCand<Cand_eta.size();iCand++){
+		int matchIdx = -1;   
+		float mcmatch_tmp_dr = 999.;
+		for(unsigned int iGen=0; iGen<GenPart_eta.size(); iGen++) {
+		    tmpDR = deltaR(Cand_eta[iCand], Cand_phi[iCand], GenPart_eta[iGen], GenPart_phi[iGen]);
+		    if (tmpDR < mcmatch_tmp_dr) {
+		        mcmatch_tmp_dr = tmpDR;
+		        matchIdx=iGen;
+		    } 
+		}
+		if (mcmatch_tmp_dr < coneDR) isGenMatched[iCand] = matchIdx;
+		else isGenMatched[iCand] = -1;
+	}
+	return isGenMatched;
+}
+*/
 
 
 // use directly the collection of gen muons define in the apporpriate way
@@ -388,43 +437,46 @@ RVec<Bool_t> hasGenMatch(RVec<Float_t> &Gen_eta, RVec<Float_t> &Gen_phi,
                          RVec<Float_t> &Cand_eta, RVec<Float_t> &Cand_phi,
                          const float coneDR = 0.1)
 {
-  RVec<Bool_t> isGenMatched;  
-  float tmpDR = 0.0; // utility variable filled below everytime
-  for(int iCand=0;iCand<Cand_eta.size();iCand++){
-    bool matchMC = false;   
-    float mcmatch_tmp_dr = 999.;
-    for(unsigned int iGen=0; iGen<Gen_eta.size(); iGen++){
-        tmpDR = deltaR(Cand_eta[iCand], Cand_phi[iCand], Gen_eta[iGen], Gen_phi[iGen]);
-        if (tmpDR < mcmatch_tmp_dr){
-            mcmatch_tmp_dr = tmpDR;
-        } 
-    }
-    if (mcmatch_tmp_dr < coneDR) matchMC = true;
-    isGenMatched.push_back(matchMC);
-  }
-  return isGenMatched;
+	RVec<Bool_t> isGenMatched;  
+	float tmpDR = 0.0; // utility variable filled below everytime
+	for(int iCand=0;iCand<Cand_eta.size();iCand++) {
+		bool matchMC = false;   
+		float mcmatch_tmp_dr = 999.;
+		for(unsigned int iGen=0; iGen<Gen_eta.size(); iGen++) {
+			tmpDR = deltaR(Cand_eta[iCand], Cand_phi[iCand], Gen_eta[iGen], Gen_phi[iGen]);
+			if (tmpDR < mcmatch_tmp_dr) {
+				mcmatch_tmp_dr = tmpDR;
+			} 
+		}
+		if ( (coneDR>0 && mcmatch_tmp_dr<coneDR) || (coneDR<0 && mcmatch_tmp_dr>-coneDR) )  matchMC = true;
+		isGenMatched.push_back(matchMC);
+	}
+	return isGenMatched;
 }
 
 
-RVec<Int_t> GenMatchedIdx(RVec<Float_t> &GenPart_eta,RVec<Float_t> &GenPart_phi,RVec<Float_t> &Cand_eta, RVec<Float_t> &Cand_phi, const float coneDR = 0.1){
-
-    RVec<Int_t> isGenMatched(Cand_eta.size(), -1); //  fill with proper size and initialize to -1  
-    float tmpDR = 0.0; // utility variable filled below everytime
-    for(int iCand=0;iCand<Cand_eta.size();iCand++){
-        int matchIdx = -1;   
-        float mcmatch_tmp_dr = 999.;
-        for(unsigned int iGen=0; iGen<GenPart_eta.size(); iGen++){
-            tmpDR = deltaR(Cand_eta[iCand], Cand_phi[iCand], GenPart_eta[iGen], GenPart_phi[iGen]);
-            if (tmpDR < mcmatch_tmp_dr){
-                mcmatch_tmp_dr = tmpDR;
-                matchIdx=iGen;
-            } 
-        }
-        if (mcmatch_tmp_dr < coneDR) isGenMatched[iCand] = matchIdx;
-        else isGenMatched[iCand] = -1;
-    }
-    return isGenMatched;
+RVec<Int_t> GenMatchedIdx(RVec<Float_t> &GenPart_eta, RVec<Float_t> &GenPart_phi,
+						  RVec<Float_t> &Cand_eta, RVec<Float_t> &Cand_phi, 
+						  const float coneDR = 0.1)
+{
+	RVec<Int_t> isGenMatched(Cand_eta.size(), -1); //  fill with proper size and initialize to -1  
+	float tmpDR = 0.0; // utility variable filled below everytime
+	for(int iCand=0;iCand<Cand_eta.size();iCand++){
+		int matchIdx = -1;   
+		float mcmatch_tmp_dr = 999.;
+		for(unsigned int iGen=0; iGen<GenPart_eta.size(); iGen++) {
+		    tmpDR = deltaR(Cand_eta[iCand], Cand_phi[iCand], GenPart_eta[iGen], GenPart_phi[iGen]);
+		    if (tmpDR < mcmatch_tmp_dr) {
+		        mcmatch_tmp_dr = tmpDR;
+		        matchIdx=iGen;
+		    } 
+		}
+		if ( (coneDR>0 && mcmatch_tmp_dr<coneDR) || (coneDR<0 && mcmatch_tmp_dr>-coneDR) ) isGenMatched[iCand] = matchIdx;
+		else isGenMatched[iCand] = -1;
+	}
+	return isGenMatched;
 }
+
 
 RVec<Float_t> getTPmass(RVec<std::pair<int,int>> TPPairs,
                         RVec<Float_t> &Muon_pt, RVec<Float_t> &Muon_eta, RVec<Float_t> &Muon_phi, 
@@ -443,6 +495,7 @@ RVec<Float_t> getTPmass(RVec<std::pair<int,int>> TPPairs,
     return TPMass;
     
 }
+
 
 RVec<Float_t> getTPabsDiffZ(RVec<std::pair<int,int>> TPPairs,
                             RVec<Float_t> &tag_Z, RVec<Float_t> &probe_Z)

--- a/Steve.h
+++ b/Steve.h
@@ -48,7 +48,6 @@ void initializeVertexPileupWeights(const std::string& _filename_vertexPileupWeig
                   << _filename_vertexPileupWeights << "! Aborting" << std::endl;
         exit(EXIT_FAILURE);
       }
-      // std::cout << "Era:" << era << std::endl;
       histptr->SetDirectory(0);
       hVertexPileupWeights[id] = *dynamic_cast<TH2D*>(histptr);
       id++;
@@ -67,8 +66,6 @@ void initializeVertexPileupWeights(const std::string& _filename_vertexPileupWeig
 
   }
   _file_vertexPileupWeights.Close();
-  
-  std::cout << "INFO >>> Histograms correctly initialized with vertex-pileup weights" << std::endl;
   
 }
 
@@ -331,7 +328,6 @@ RVec<Bool_t> hasTriggerMatch2018(RVec<Float_t> &Muon_eta, RVec<Float_t> &Muon_ph
   return TriggerMatch;
 }
 
-/*
 RVec<Bool_t> hasGenMatch(RVec<Int_t> &GenPart_pdgId, RVec<Int_t> &GenPart_status,
 			 RVec<Int_t> &GenPart_statusFlags, RVec<Float_t> &GenPart_eta,
 			 RVec<Float_t> &GenPart_phi, RVec<Float_t> &Cand_eta, 
@@ -360,6 +356,7 @@ RVec<Bool_t> hasGenMatch(RVec<Int_t> &GenPart_pdgId, RVec<Int_t> &GenPart_status
   return isGenMatched;
 }
 
+
 RVec<Int_t> GenMatchedIdx(RVec<Int_t> &GenPart_pdgId, RVec<Int_t> &GenPart_status,RVec<Int_t> &GenPart_statusFlags,RVec<Float_t> &GenPart_eta,RVec<Float_t> &GenPart_phi,RVec<Float_t> &Cand_eta, RVec<Float_t> &Cand_phi, const float coneDR = 0.1){
   RVec<Int_t> isGenMatched;  
   for(int iCand=0;iCand<Cand_eta.size();iCand++){
@@ -381,55 +378,6 @@ RVec<Int_t> GenMatchedIdx(RVec<Int_t> &GenPart_pdgId, RVec<Int_t> &GenPart_statu
   }
   return isGenMatched;
 }
-*/
-
-// USE THE FOLLOWING TWO FUNCTIONS
-/*
-// use directly the collection of gen muons define in the apporpriate way
-RVec<Bool_t> hasGenMatch(RVec<Float_t> &Gen_eta, RVec<Float_t> &Gen_phi,
-                         RVec<Float_t> &Cand_eta, RVec<Float_t> &Cand_phi,
-                         const float coneDR = 0.1)
-{
-	RVec<Bool_t> isGenMatched;  
-	float tmpDR = 0.0; // utility variable filled below everytime
-	for(int iCand=0;iCand<Cand_eta.size();iCand++) {
-		bool matchMC = false;   
-		float mcmatch_tmp_dr = 999.;
-		for(unsigned int iGen=0; iGen<Gen_eta.size(); iGen++) {
-			tmpDR = deltaR(Cand_eta[iCand], Cand_phi[iCand], Gen_eta[iGen], Gen_phi[iGen]);
-			if (tmpDR < mcmatch_tmp_dr) {
-				mcmatch_tmp_dr = tmpDR;
-			} 
-		}
-		if (mcmatch_tmp_dr < coneDR) matchMC = true;
-		isGenMatched.push_back(matchMC);
-	}
-	return isGenMatched;
-}
-
-
-RVec<Int_t> GenMatchedIdx(RVec<Float_t> &GenPart_eta, RVec<Float_t> &GenPart_phi,
-						  RVec<Float_t> &Cand_eta, RVec<Float_t> &Cand_phi, 
-						  const float coneDR = 0.1)
-{
-	RVec<Int_t> isGenMatched(Cand_eta.size(), -1); //  fill with proper size and initialize to -1  
-	float tmpDR = 0.0; // utility variable filled below everytime
-	for(int iCand=0;iCand<Cand_eta.size();iCand++){
-		int matchIdx = -1;   
-		float mcmatch_tmp_dr = 999.;
-		for(unsigned int iGen=0; iGen<GenPart_eta.size(); iGen++) {
-		    tmpDR = deltaR(Cand_eta[iCand], Cand_phi[iCand], GenPart_eta[iGen], GenPart_phi[iGen]);
-		    if (tmpDR < mcmatch_tmp_dr) {
-		        mcmatch_tmp_dr = tmpDR;
-		        matchIdx=iGen;
-		    } 
-		}
-		if (mcmatch_tmp_dr < coneDR) isGenMatched[iCand] = matchIdx;
-		else isGenMatched[iCand] = -1;
-	}
-	return isGenMatched;
-}
-*/
 
 
 // use directly the collection of gen muons define in the apporpriate way
@@ -437,46 +385,43 @@ RVec<Bool_t> hasGenMatch(RVec<Float_t> &Gen_eta, RVec<Float_t> &Gen_phi,
                          RVec<Float_t> &Cand_eta, RVec<Float_t> &Cand_phi,
                          const float coneDR = 0.1)
 {
-	RVec<Bool_t> isGenMatched;  
-	float tmpDR = 0.0; // utility variable filled below everytime
-	for(int iCand=0;iCand<Cand_eta.size();iCand++) {
-		bool matchMC = false;   
-		float mcmatch_tmp_dr = 999.;
-		for(unsigned int iGen=0; iGen<Gen_eta.size(); iGen++) {
-			tmpDR = deltaR(Cand_eta[iCand], Cand_phi[iCand], Gen_eta[iGen], Gen_phi[iGen]);
-			if (tmpDR < mcmatch_tmp_dr) {
-				mcmatch_tmp_dr = tmpDR;
-			} 
-		}
-		if ( (coneDR>0 && mcmatch_tmp_dr<coneDR) || (coneDR<0 && mcmatch_tmp_dr>-coneDR) )  matchMC = true;
-		isGenMatched.push_back(matchMC);
-	}
-	return isGenMatched;
+  RVec<Bool_t> isGenMatched;  
+  float tmpDR = 0.0; // utility variable filled below everytime
+  for(int iCand=0;iCand<Cand_eta.size();iCand++){
+    bool matchMC = false;   
+    float mcmatch_tmp_dr = 999.;
+    for(unsigned int iGen=0; iGen<Gen_eta.size(); iGen++){
+        tmpDR = deltaR(Cand_eta[iCand], Cand_phi[iCand], Gen_eta[iGen], Gen_phi[iGen]);
+        if (tmpDR < mcmatch_tmp_dr){
+            mcmatch_tmp_dr = tmpDR;
+        } 
+    }
+    if (mcmatch_tmp_dr < coneDR) matchMC = true;
+    isGenMatched.push_back(matchMC);
+  }
+  return isGenMatched;
 }
 
 
-RVec<Int_t> GenMatchedIdx(RVec<Float_t> &GenPart_eta, RVec<Float_t> &GenPart_phi,
-						  RVec<Float_t> &Cand_eta, RVec<Float_t> &Cand_phi, 
-						  const float coneDR = 0.1)
-{
-	RVec<Int_t> isGenMatched(Cand_eta.size(), -1); //  fill with proper size and initialize to -1  
-	float tmpDR = 0.0; // utility variable filled below everytime
-	for(int iCand=0;iCand<Cand_eta.size();iCand++){
-		int matchIdx = -1;   
-		float mcmatch_tmp_dr = 999.;
-		for(unsigned int iGen=0; iGen<GenPart_eta.size(); iGen++) {
-		    tmpDR = deltaR(Cand_eta[iCand], Cand_phi[iCand], GenPart_eta[iGen], GenPart_phi[iGen]);
-		    if (tmpDR < mcmatch_tmp_dr) {
-		        mcmatch_tmp_dr = tmpDR;
-		        matchIdx=iGen;
-		    } 
-		}
-		if ( (coneDR>0 && mcmatch_tmp_dr<coneDR) || (coneDR<0 && mcmatch_tmp_dr>-coneDR) ) isGenMatched[iCand] = matchIdx;
-		else isGenMatched[iCand] = -1;
-	}
-	return isGenMatched;
-}
+RVec<Int_t> GenMatchedIdx(RVec<Float_t> &GenPart_eta,RVec<Float_t> &GenPart_phi,RVec<Float_t> &Cand_eta, RVec<Float_t> &Cand_phi, const float coneDR = 0.1){
 
+    RVec<Int_t> isGenMatched(Cand_eta.size(), -1); //  fill with proper size and initialize to -1  
+    float tmpDR = 0.0; // utility variable filled below everytime
+    for(int iCand=0;iCand<Cand_eta.size();iCand++){
+        int matchIdx = -1;   
+        float mcmatch_tmp_dr = 999.;
+        for(unsigned int iGen=0; iGen<GenPart_eta.size(); iGen++){
+            tmpDR = deltaR(Cand_eta[iCand], Cand_phi[iCand], GenPart_eta[iGen], GenPart_phi[iGen]);
+            if (tmpDR < mcmatch_tmp_dr){
+                mcmatch_tmp_dr = tmpDR;
+                matchIdx=iGen;
+            } 
+        }
+        if (mcmatch_tmp_dr < coneDR) isGenMatched[iCand] = matchIdx;
+        else isGenMatched[iCand] = -1;
+    }
+    return isGenMatched;
+}
 
 RVec<Float_t> getTPmass(RVec<std::pair<int,int>> TPPairs,
                         RVec<Float_t> &Muon_pt, RVec<Float_t> &Muon_eta, RVec<Float_t> &Muon_phi, 
@@ -495,7 +440,6 @@ RVec<Float_t> getTPmass(RVec<std::pair<int,int>> TPPairs,
     return TPMass;
     
 }
-
 
 RVec<Float_t> getTPabsDiffZ(RVec<std::pair<int,int>> TPPairs,
                             RVec<Float_t> &tag_Z, RVec<Float_t> &probe_Z)

--- a/Steve.py
+++ b/Steve.py
@@ -57,6 +57,13 @@ def makeAndSaveHistograms(d, histo_name, histo_title, binning_mass, binning_pt, 
     makeAndSaveOneHist(d, histo_name, histo_title, binning_mass, binning_pt, binning_eta, massVar, isPass=True)
     makeAndSaveOneHist(d, histo_name, histo_title, binning_mass, binning_pt, binning_eta, massVar, isPass=False)
     
+    ######
+    model_deltaR = ROOT.RDF.TH1DModel(f"dR", f"dR(probe,gen)", 320, 0, 5.5)
+    deltaR_hist = d.Histo1D(model_deltaR, "dR_SA_gen_fail")
+    print(deltaR_hist.Integral())
+    deltaR_hist.Write()
+    ######
+    
 
 
 def make_jsonhelper(filename):
@@ -79,68 +86,73 @@ def make_jsonhelper(filename):
 
 parser = argparse.ArgumentParser()
 
-parser.add_argument("-e","--efficiency",
-		    help="1 for reco, 2 for \"tracking\", 3 for idip, 4 for trigger, 5 for isolation, 6 for isolation without trigger, 7 for veto, 8 for isolation with failing trigger",
+parser.add_argument("-e", "--efficiency", 
+					help="1 for reco, 2 for \"tracking\", 3 for idip, 4 for trigger, 5 for isolation, 6 for isolation without trigger, 7 for veto, 8 for isolation with failing trigger",
                     type=int, choices=range(1,9))
 
 #parser.add_argument("-i","--input_path", help="path of the input root files", type=str)
 
-parser.add_argument("-i","--input_path", nargs='+', default=[], help="path of the input root files")
+parser.add_argument("-i", "--input_path", help="path of the input root files",
+					nargs='+', default=[])
 
-parser.add_argument("-o","--output_file", help="name of the output root file",
+parser.add_argument("-o", "--output_file", help="name of the output root file",
                     type=str)
 
-parser.add_argument("-d","--isData", help="Pass 0 for MC, 1 for Data, default is 0",
-                    type=int, default=0)
+parser.add_argument("-d", "--isData", help="Pass 0 for MC, 1 for Data, default is 0",
+                    type=int, default=0, choices=[0,1])
 
-parser.add_argument("-b","--isBkg", help="Pass 0 for MC and Data, 1 for Bkg, default is 0",
-                    type=int, default=0)
-parser.add_argument("-tpt","--tagPt", help="Minimum pt to select tag muons",
+parser.add_argument("-b", "--isBkg", help="Pass 0 for MC and Data, 1 for Bkg, default is 0",
+                    type=int, default=0, choices=[0,1])
+                    
+parser.add_argument("-tpt", "--tagPt", help="Minimum pt to select tag muons",
                     type=float, default=25.)
 
-parser.add_argument("-tiso","--tagIso", help="Isolation threshold to select tag muons",
+parser.add_argument("-tiso", "--tagIso", help="Isolation threshold to select tag muons",
                     type=float, default=0.15)
 
 parser.add_argument(        "--standaloneValidHits", help="Minimum number of valid hits for the standalone track (>= this value)",
                     type=int, default=1)
 
-parser.add_argument("-c","--charge", help="Make efficiencies for a specific charge of the probe (-1/1 for positive negative, 0 for inclusive)",
-                    type=int, default=0, choices=[-1, 0, 1])
+parser.add_argument("-c", "--charge", help="Make efficiencies for a specific charge of the probe (-1/1 for positive negative, 0 for inclusive)",
+                    type=int, default=0, choices=[-1,0,1])
 
-parser.add_argument("-p","--eventParity", help="Select events with given parity for statistical tests, -1/1 for odd/even events, 0 for all (default)",
-                    type=int, default=0, choices=[-1, 0, 1])
+parser.add_argument("-p", "--eventParity", help="Select events with given parity for statistical tests, -1/1 for odd/even events, 0 for all (default)",
+                    type=int, default=0, choices=[-1,0,1])
 
 parser.add_argument('-nw', '--noVertexPileupWeight', action='store_true', help='Do not use weights for vertex z position')
 #parser.add_argument("-vpw", "--vertexPileupWeight", action="store_true", help="Use weights for vertex z position versus pileup (only for MC)")
 
+parser.add_argument('-ngm', '--noGenMatching', action='store_true', help='Do not apply gen-matching for the probe (for non prompt bkg study)')
+
+parser.add_argument(        '--reverseGenMatching', action='store_true', help='Reverse the gen-matching condition for the probe (for non prompt contributions on Zmumu sample)')
+
 parser.add_argument("-nos", "--noOppositeCharge", action="store_true", help="Don't require opposite charges between tag and probe (including tracking, unless also using --noOppositeChargeTracking)")
+
 parser.add_argument(        "--noOppositeChargeTracking", action="store_true", help="Don't require opposite charges between tag and probe for tracking")
 
-parser.add_argument("-sc", "--SameCharge", action="store_true", help="Require the TP Pair to have same sign (fo bkg study)",
-                     default=False)
+parser.add_argument("-sc", "--SameCharge", action="store_true", help="Require the TP Pair to have same sign (for bkg study)")
 
-parser.add_argument("-zqt","--zqtprojection", action="store_true", help="Efficiencies evaluated as a function of zqtprojection (only for trigger and isolation)")
+parser.add_argument("-zqt", "--zqtprojection", action="store_true", help="Efficiencies evaluated as a function of zqtprojection (only for trigger and isolation)")
 
-parser.add_argument("-gen","--genLevelEfficiency", action="store_true", help="Compute MC truth efficiency")
+parser.add_argument("-gen", "--genLevelEfficiency", action="store_true", help="Compute MC truth efficiency")
 
-parser.add_argument("-tpg","--tnpGenLevel", action="store_true", help="Compute tag-and-probe efficiencies for MC as a function of postVFP gen variables")
+parser.add_argument("-tpg", "--tnpGenLevel", action="store_true", help="Compute tag-and-probe efficiencies for MC as a function of postVFP gen variables")
 
-parser.add_argument("-y","--year", help="run year 2016, 2017, 2018",
-                    type=str,default="2016")
-parser.add_argument("-iso","--isoDefinition",help="Choose between the old and new isolation definition, 0 is old, 1 is new", default=1, choices = [0,1], type =int)
+parser.add_argument("-y", "--year", help="run year 2016, 2017, 2018", 
+					type=str, default="2016", choices=["2016","2017","2018"])
+
+parser.add_argument("-iso", "--isoDefinition", help="Choose between the old and new isolation definition, 0 is old, 1 is new", 
+					type=int, default=1, choices=[0,1])
 
 args = parser.parse_args()
 tstart = time.time()
 cpustrat = time.process_time()
 
-if args.isData & args.genLevelEfficiency:
-    raise RuntimeError('\'genLevelEfficiency\' option not supported for data')
+if args.isData & args.genLevelEfficiency: raise RuntimeError('\'genLevelEfficiency\' option not supported for data')
 
-if args.isData & args.tnpGenLevel:
-    raise RuntimeError('\'tnpGenLevel\' option not supported for data')
+if args.isData & args.tnpGenLevel: raise RuntimeError('\'tnpGenLevel\' option not supported for data')
 
-if not args.output_file.endswith(".root"):
-    raise NameError('output_file name must end with \'.root\'')
+if not args.output_file.endswith(".root"): raise NameError('output_file name must end with \'.root\'')
 
 # create output folders if not existing
 outdir = os.path.dirname(os.path.abspath(args.output_file))
@@ -177,7 +189,6 @@ if args.charge and args.efficiency in [2]:
     print("")
 
 
-#print(files)
 filenames = ROOT.std.vector('string')()
 
 for name in files: filenames.push_back(name)
@@ -251,16 +262,21 @@ if args.eventParity < 0:
 elif args.eventParity > 0:
     d = d.Filter("(event % 2) == 0") # even
 
+
+# Opposite/same sign of tag and probes
 doOS = 0 if args.noOppositeCharge else 1
 doOStracking = 0 if args.noOppositeChargeTracking else doOS
 
 SS = 1 if args.SameCharge else 0
 
-if doOS & SS:
-    raise Exception("Both doOS and SS can't be True. Require noOppositeCharge if you really want the Same Sign")
+if doOS & SS: 		  raise Exception("Both doOS and SS can't be True. Require noOppositeCharge if you really want the Same Sign")
+if doOStracking & SS: raise Exception("Both doOStracking and SS can't be True. Require noOppositeChargeTracking if you really want Same Sign")
 
-if doOStracking & SS:
-    raise Exception("Both doOStracking and SS can't be True. Require noOppositeChargeTracking if you rally want Same Sign")
+'''
+# Gen-matching control
+if args.reverseGenMatching and (args.isData==1 or args.isBkg==1):
+	raise Exception("The 'reverse' condition on gen-matching can be applied only when running on mc signal dataset") 
+'''
 
 if (args.isData == 1):
     if (args.year == "2016"): 
@@ -374,180 +390,188 @@ f_out = ROOT.TFile(args.output_file, "RECREATE")
     
 ## Tracks for reco efficiency
 if(args.efficiency == 1):
-    if not (args.genLevelEfficiency):
+	if not (args.genLevelEfficiency):
 
-        if (args.isData==1) or (args.isBkg==1):
-            d = d.Define("isGenMatchedTrack","createTrues(nTrack)")
-        else:
-            d = d.Define("isGenMatchedTrack", "hasGenMatch(GenMuonBare_eta, GenMuonBare_phi, Track_eta, Track_phi)")
-            d = d.Define("GenMatchedIdx", "GenMatchedIdx(GenMuonBare_eta, GenMuonBare_phi, Track_eta, Track_phi)")
+		if (args.noGenMatching or args.isData==1) and not args.reverseGenMatching:
+			d = d.Define("isGenMatchedTrack","createTrues(nTrack)")
+		else:
+			genMatchCut = 0.1 if not args.reverseGenMatching else -0.1
+			d = d.Define("isGenMatchedTrack", f"hasGenMatch(GenMuonBare_eta, GenMuonBare_phi, Track_eta, Track_phi, {genMatchCut})")
+			d = d.Define("GenMatchedIdx", f"GenMatchedIdx(GenMuonBare_eta, GenMuonBare_phi, Track_eta, Track_phi, {genMatchCut})")
 
-        chargeCut = ""
-        if args.charge:
-            sign= ">" if args.charge > 0 else "<"
-            chargeCut = f" && Track_charge {sign} 0"
+		chargeCut = ""
+		if args.charge:
+			sign= ">" if args.charge > 0 else "<"
+			chargeCut = f" && Track_charge {sign} 0"
 
-            
-        # define all probes
-        d = d.Define("Probe_Tracks", f"Track_pt > 24 && abs(Track_eta) < 2.4 && Track_trackOriginalAlgo != 13 && Track_trackOriginalAlgo != 14 && isGenMatchedTrack && (Track_qualityMask & 4) {chargeCut}")
-        # condition for passing probes
-        # FIXME: add other criteria to the MergedStandAloneMuon to accept the matching? E.g. |eta| < 2.4 or pt > XX? No, it is an acceptance on numerator which we don't want
-        d = d.Define("goodStandaloneMuon", f"MergedStandAloneMuon_pt > 15 && MergedStandAloneMuon_numberOfValidHits >= {minStandaloneNumberOfValidHits}")
-        d = d.Define("passCondition_reco", "trackStandaloneDR(Track_eta, Track_phi, MergedStandAloneMuon_eta[goodStandaloneMuon], MergedStandAloneMuon_phi[goodStandaloneMuon]) < 0.3")
+		# define all probes
+		d = d.Define("Probe_Tracks", f"Track_pt > 24 && abs(Track_eta) < 2.4 && Track_trackOriginalAlgo != 13 && Track_trackOriginalAlgo != 14 && isGenMatchedTrack && (Track_qualityMask & 4) {chargeCut}")
+		# condition for passing probes
+		# FIXME: add other criteria to the MergedStandAloneMuon to accept the matching? E.g. |eta| < 2.4 or pt > XX? No, it is an acceptance on numerator which we don't want
+		d = d.Define("goodStandaloneMuon", f"MergedStandAloneMuon_pt > 15 && MergedStandAloneMuon_numberOfValidHits >= {minStandaloneNumberOfValidHits}")
+		d = d.Define("passCondition_reco", "trackStandaloneDR(Track_eta, Track_phi, MergedStandAloneMuon_eta[goodStandaloneMuon], MergedStandAloneMuon_phi[goodStandaloneMuon]) < 0.3")
+
+		d = d.Define("All_TPPairs", f"CreateTPPair(Tag_Muons, Probe_Tracks, {doOS}, Tag_charge, Track_charge, Tag_inExtraIdx, Track_extraIdx, 0, {SS})")
+		d = d.Define("All_TPmass", "getTPmass(All_TPPairs, Tag_pt, Tag_eta, Tag_phi, Track_pt, Track_eta, Track_phi)")
+		d = d.Define("All_absDiffZ", "getTPabsDiffZ(All_TPPairs, Tag_Z, Track_Z)")
+
+		# overriding previous pt binning
+		#binning_pt = array('d',[24., 65.])
+		#binning_pt = array('d',[24., 26., 30., 34., 38., 42., 46., 50., 55., 65.])
+		binning_pt = array('d',[24., 26., 30., 34., 38., 42., 46., 50., 55., 60., 65.])
+		## binning is currently 50,130 GeV, but it is overridden below 
+		# also for mass
+		massLow  =  60
+		massHigh = 120
+		binning_mass = array('d',[massLow + i for i in range(int(1+massHigh-massLow))])
+		massCut = f"All_TPmass > {massLow} && All_TPmass < {massHigh}"
+		ZdiffCut = "All_absDiffZ < 0.2"
+		d = d.Define("TPPairs", f"All_TPPairs[{massCut} && {ZdiffCut}]")
+		d = d.Define("TPmass",  f"All_TPmass[{massCut}  && {ZdiffCut}]")
+
+		d = d.Define("Probe_pt",   "getVariables(TPPairs, Track_pt,  2)")
+		d = d.Define("Probe_eta",  "getVariables(TPPairs, Track_eta, 2)")
+		d = d.Define("passCondition", "getVariables(TPPairs, passCondition_reco, 2)")
+		d = d.Define("failCondition", "!passCondition")
+
+		if (args.tnpGenLevel):
+			d = d.Redefine("Probe_pt","getGenVariables(TPPairs,GenMatchedIdx,GenMuonBare_pt,2)")
+			d = d.Redefine("Probe_eta","getGenVariables(TPPairs,GenMatchedIdx,GenMuonBare_eta,2)")
+
+		d = d.Define("Probe_pt_pass",  "Probe_pt[passCondition]")
+		d = d.Define("Probe_eta_pass", "Probe_eta[passCondition]")
+		d = d.Define("TPmass_pass", "TPmass[passCondition]")
+		d = d.Define("Probe_pt_fail",  "Probe_pt[failCondition]")
+		d = d.Define("Probe_eta_fail", "Probe_eta[failCondition]")
+		d = d.Define("TPmass_fail", "TPmass[failCondition]")
+		makeAndSaveHistograms(d, histo_name, "Reco", binning_mass, binning_pt, binning_eta)
         
-        d = d.Define("All_TPPairs", f"CreateTPPair(Tag_Muons, Probe_Tracks, {doOS}, Tag_charge, Track_charge, Tag_inExtraIdx, Track_extraIdx, 0, {SS})")
-        d = d.Define("All_TPmass", "getTPmass(All_TPPairs, Tag_pt, Tag_eta, Tag_phi, Track_pt, Track_eta, Track_phi)")
-        d = d.Define("All_absDiffZ", "getTPabsDiffZ(All_TPPairs, Tag_Z, Track_Z)")
-        
-        # overriding previous pt binning
-        #binning_pt = array('d',[24., 65.])
-        #binning_pt = array('d',[24., 26., 30., 34., 38., 42., 46., 50., 55., 65.])
-        binning_pt = array('d',[24., 26., 30., 34., 38., 42., 46., 50., 55., 60., 65.])
-        ## binning is currently 50,130 GeV, but it is overridden below 
-        # also for mass
-        massLow  =  60
-        massHigh = 120
-        binning_mass = array('d',[massLow + i for i in range(int(1+massHigh-massLow))])
-        massCut = f"All_TPmass > {massLow} && All_TPmass < {massHigh}"
-        ZdiffCut = "All_absDiffZ < 0.2"
-        d = d.Define("TPPairs", f"All_TPPairs[{massCut} && {ZdiffCut}]")
-        d = d.Define("TPmass",  f"All_TPmass[{massCut}  && {ZdiffCut}]")
-        
-        d = d.Define("Probe_pt",   "getVariables(TPPairs, Track_pt,  2)")
-        d = d.Define("Probe_eta",  "getVariables(TPPairs, Track_eta, 2)")
-        d = d.Define("passCondition", "getVariables(TPPairs, passCondition_reco, 2)")
-        d = d.Define("failCondition", "!passCondition")
+	else:
+		d = d.Define("goodmuon","goodmuonreco(goodgeneta,goodgenphi,MergedStandAloneMuon_pt,MergedStandAloneMuon_eta,MergedStandAloneMuon_phi)").Define("newweight","weight*goodmuon")
 
-        if (args.tnpGenLevel):
-            d = d.Redefine("Probe_pt","getGenVariables(TPPairs,GenMatchedIdx,GenMuonBare_pt,2)")
-            d = d.Redefine("Probe_eta","getGenVariables(TPPairs,GenMatchedIdx,GenMuonBare_eta,2)")
-        
-        d = d.Define("Probe_pt_pass",  "Probe_pt[passCondition]")
-        d = d.Define("Probe_eta_pass", "Probe_eta[passCondition]")
-        d = d.Define("TPmass_pass", "TPmass[passCondition]")
-        d = d.Define("Probe_pt_fail",  "Probe_pt[failCondition]")
-        d = d.Define("Probe_eta_fail", "Probe_eta[failCondition]")
-        d = d.Define("TPmass_fail", "TPmass[failCondition]")
-        makeAndSaveHistograms(d, histo_name, "Reco", binning_mass, binning_pt, binning_eta)
-        
-    else:
-        d = d.Define("goodmuon","goodmuonreco(goodgeneta,goodgenphi,MergedStandAloneMuon_pt,MergedStandAloneMuon_eta,MergedStandAloneMuon_phi)").Define("newweight","weight*goodmuon")
+		model_pass_reco = ROOT.RDF.TH2DModel("Pass","",len(binning_eta)-1,binning_eta,len(binning_pt)-1,binning_pt)
+		model_norm_reco = ROOT.RDF.TH2DModel("Norm","",len(binning_eta)-1,binning_eta,len(binning_pt)-1,binning_pt)
 
-        model_pass_reco = ROOT.RDF.TH2DModel("Pass","",len(binning_eta)-1,binning_eta,len(binning_pt)-1,binning_pt)
-        model_norm_reco = ROOT.RDF.TH2DModel("Norm","",len(binning_eta)-1,binning_eta,len(binning_pt)-1,binning_pt)
+		pass_histogram_reco = d.Histo2D(model_pass_reco,"goodgeneta","goodgenpt","newweight")
+		pass_histogram_norm = d.Histo2D(model_norm_reco,"goodgeneta","goodgenpt","weight")
 
-        pass_histogram_reco = d.Histo2D(model_pass_reco,"goodgeneta","goodgenpt","newweight")
-        pass_histogram_norm = d.Histo2D(model_norm_reco,"goodgeneta","goodgenpt","weight")
-
-        pass_histogram_reco.Write()
-        pass_histogram_norm.Write()
+		pass_histogram_reco.Write()
+		pass_histogram_norm.Write()
 
 
 #Global|MergedStandAloneMuon ("tracking" efficiency)
 elif (args.efficiency == 2):
-    if not (args.genLevelEfficiency):
-        if (args.isData==1) or (args.isBkg==1):
-            d = d.Define("isGenMatchedMergedStandMuon", "createTrues(nMergedStandAloneMuon)")
-        else:
-            d = d.Define("isGenMatchedMergedStandMuon","hasGenMatch(GenMuonBare_eta, GenMuonBare_phi, MergedStandAloneMuon_eta, MergedStandAloneMuon_phi, 0.3)")
-            d = d.Define("GenMatchedIdx","GenMatchedIdx(GenMuonBare_eta, GenMuonBare_phi, MergedStandAloneMuon_eta, MergedStandAloneMuon_phi, 0.3)")
+	if not (args.genLevelEfficiency):
+		if (args.noGenMatching or args.isData==1) and not args.reverseGenMatching:
+			d = d.Define("isGenMatchedMergedStandMuon", "createTrues(nMergedStandAloneMuon)")
+		else:
+			genMatchCut = 0.3 if not args.reverseGenMatching else -0.3
+			d = d.Define("isGenMatchedMergedStandMuon", f"hasGenMatch(GenMuonBare_eta, GenMuonBare_phi, MergedStandAloneMuon_eta, MergedStandAloneMuon_phi, {genMatchCut})")
+			d = d.Define("GenMatchedIdx", f"GenMatchedIdx(GenMuonBare_eta, GenMuonBare_phi, MergedStandAloneMuon_eta, MergedStandAloneMuon_phi, {genMatchCut})")
 
-        # All probes, standalone muons from MergedStandAloneMuon_XX    
-        d = d.Define("Probe_MergedStandMuons",f"MergedStandAloneMuon_pt > 15 && abs(MergedStandAloneMuon_eta) < 2.4 && isGenMatchedMergedStandMuon && MergedStandAloneMuon_numberOfValidHits >= {minStandaloneNumberOfValidHits}")
-        #
-        d = d.Define("All_TPPairs", f"CreateTPPair(Tag_Muons, Probe_MergedStandMuons, {doOStracking}, Tag_charge, MergedStandAloneMuon_charge, Tag_outExtraIdx, MergedStandAloneMuon_extraIdx, 0, {SS})")
-        d = d.Define("All_TPmass","getTPmass(All_TPPairs, Tag_pt, Tag_eta, Tag_phi, MergedStandAloneMuon_pt, MergedStandAloneMuon_eta, MergedStandAloneMuon_phi)")
+		# All probes, standalone muons from MergedStandAloneMuon_XX    
+		d = d.Define("Probe_MergedStandMuons",f"MergedStandAloneMuon_pt > 15 && abs(MergedStandAloneMuon_eta) < 2.4 && isGenMatchedMergedStandMuon && MergedStandAloneMuon_numberOfValidHits >= {minStandaloneNumberOfValidHits}")
+		#
+		d = d.Define("All_TPPairs", f"CreateTPPair(Tag_Muons, Probe_MergedStandMuons, {doOStracking}, Tag_charge, MergedStandAloneMuon_charge, Tag_outExtraIdx, MergedStandAloneMuon_extraIdx, 0, {SS})")
+		d = d.Define("All_TPmass","getTPmass(All_TPPairs, Tag_pt, Tag_eta, Tag_phi, MergedStandAloneMuon_pt, MergedStandAloneMuon_eta, MergedStandAloneMuon_phi)")
 
-        massLow  =  50
-        massHigh = 130
-        binning_mass = array('d',[massLow + i for i in range(int(1+massHigh-massLow))])
-        massCut = f"All_TPmass > {massLow} && All_TPmass < {massHigh}"
-        d = d.Define("TPPairs", f"All_TPPairs[{massCut}]")
-        d = d.Define("TPmass",  f"All_TPmass[{massCut}]")
 
-        d = d.Define("Probe_pt",  "getVariables(TPPairs, MergedStandAloneMuon_pt,  2)")
-        d = d.Define("Probe_eta", "getVariables(TPPairs, MergedStandAloneMuon_eta, 2)")
+		massLow  =  50
+		massHigh = 130
+		binning_mass = array('d',[massLow + i for i in range(int(1+massHigh-massLow))])
+		massCut = f"All_TPmass > {massLow} && All_TPmass < {massHigh}"
+		d = d.Define("TPPairs", f"All_TPPairs[{massCut}]")
+		d = d.Define("TPmass",  f"All_TPmass[{massCut}]")
 
-        if (args.tnpGenLevel):
-            d = d.Redefine("Probe_pt","getGenVariables(TPPairs,GenMatchedIdx,GenMuonBare_pt,2)")
-            d = d.Redefine("Probe_eta","getGenVariables(TPPairs,GenMatchedIdx,GenMuonBare_eta,2)")
+		d = d.Define("Probe_pt",  "getVariables(TPPairs, MergedStandAloneMuon_pt,  2)")
+		d = d.Define("Probe_eta", "getVariables(TPPairs, MergedStandAloneMuon_eta, 2)")
+		d = d.Define("Probe_phi", "getVariables(TPPairs, MergedStandAloneMuon_phi, 2)")
 
-        # condition for passing probe, start from Muon_XX and then add match of extraID indices between Muon and MergedStandAloneMuon
-        #d = d.Define("globalMuon_standaloneNvalidHits", "getGlobalMuon_MergedStandAloneMuonVar(Muon_standaloneExtraIdx, MergedStandAloneMuon_extraIdx, MergedStandAloneMuon_numberOfValidHits)")
-        d = d.Define("Muon_forTracking", "Muon_isGlobal && Muon_pt > 10 && Muon_standalonePt > 15 && selfDeltaR(Muon_eta, Muon_phi, Muon_standaloneEta, Muon_standalonePhi) < 0.3 && Muon_highPurity")
-        ## && globalMuon_standaloneNvalidHits >= {minStandaloneNumberOfValidHits}
-        # 
-        # check Muon exists with proper criteria and matching extraIdx with the standalone muon 
-        # Note: no need to enforce the number of valid hits of the standalone track for the global muon,
-        ##      since it is already embedded in the denominator
-        ##      and the matching already ensures it is propagated to the numerator
-        d = d.Define("passCondition_tracking",
-                     "Probe_isMatched(TPPairs, MergedStandAloneMuon_extraIdx, Muon_standaloneExtraIdx, Muon_forTracking)")
-        # the following was equivalent but with an additional check between probe and tag, to exclude having the same inner track, it should not be necessary
-        #d = d.Define("passCondition_tracking",
-        #             "Probe_isGlobal_checkExtraIdxTagInnerTrack(TPPairs, MergedStandAloneMuon_extraIdx, Muon_standaloneExtraIdx, Muon_forTracking, Tag_inExtraIdx, Muon_innerTrackExtraIdx)")
-        d = d.Define("passCondition", "getVariables(TPPairs, passCondition_tracking, 2)")
-        d = d.Define("failCondition", "!passCondition")
-        
-        # use the minimum pt of the standalone muon used above to define the range, also a larger upper edge because the pt resolution of standalone muons is bad
-        #binning_pt = array('d',[15., 80.]) # try also 24,65
-        #binning_pt = array('d',[15., 30., 45., 60., 80.])
-        #binning_pt = array('d',[15., 25., 35., 45., 55., 65., 80.])
-        #binning_pt = array('d',[24., 65.])
-        binning_pt = array('d',[24., 35., 45., 55., 65.])
-        #binning_pt = array('d',[(15.0 + i*1.0) for i in range(66) ])
-        
-        # Here we are using the muon variables to calulate the mass for the passing probes for tracking efficiency
-        ## However the TPPairs were made using indices from MergedStandAloneMuon_XX collections, which are not necessarily valid for Muon_XX
-        ## Thus, for each passing MergedStandAloneMuon I store the pt,eta,phi of the corresponding Muon (which exists as long as we use the MergedStandAloneMuon indices from TPPairs_pass)
-        d = d.Define("TPPairs_pass", "TPPairs[passCondition]")
-        d = d.Define("MergedStandaloneMuon_MuonIdx", "getMergedStandAloneMuon_MuonIdx(MergedStandAloneMuon_extraIdx, Muon_standaloneExtraIdx)")
-        d = d.Define("MergedStandaloneMuon_MuonPt",  "getMergedStandAloneMuon_matchedObjectVar(MergedStandaloneMuon_MuonIdx, Muon_pt)")
-        d = d.Define("MergedStandaloneMuon_MuonEta", "getMergedStandAloneMuon_matchedObjectVar(MergedStandaloneMuon_MuonIdx, Muon_eta)")
-        d = d.Define("MergedStandaloneMuon_MuonPhi", "getMergedStandAloneMuon_matchedObjectVar(MergedStandaloneMuon_MuonIdx, Muon_phi)")
+		if (args.tnpGenLevel):
+			d = d.Redefine("Probe_pt","getGenVariables(TPPairs,GenMatchedIdx,GenMuonBare_pt,2)")
+			d = d.Redefine("Probe_eta","getGenVariables(TPPairs,GenMatchedIdx,GenMuonBare_eta,2)")
 
-        d = d.Define("TPmass_pass",    "getTPmass(TPPairs_pass, Tag_pt, Tag_eta, Tag_phi, MergedStandaloneMuon_MuonPt, MergedStandaloneMuon_MuonEta, MergedStandaloneMuon_MuonPhi)")
-        d = d.Define("Probe_pt_pass",  "Probe_pt[passCondition]")
-        d = d.Define("Probe_eta_pass", "Probe_eta[passCondition]")
+		# condition for passing probe, start from Muon_XX and then add match of extraID indices between Muon and MergedStandAloneMuon
+		#d = d.Define("globalMuon_standaloneNvalidHits", "getGlobalMuon_MergedStandAloneMuonVar(Muon_standaloneExtraIdx, MergedStandAloneMuon_extraIdx, MergedStandAloneMuon_numberOfValidHits)")
+		d = d.Define("Muon_forTracking", "Muon_isGlobal && Muon_pt > 10 && Muon_standalonePt > 15 && selfDeltaR(Muon_eta, Muon_phi, Muon_standaloneEta, Muon_standalonePhi) < 0.3 && Muon_highPurity")
+		## && globalMuon_standaloneNvalidHits >= {minStandaloneNumberOfValidHits}
+		# 
+		# check Muon exists with proper criteria and matching extraIdx with the standalone muon 
+		# Note: no need to enforce the number of valid hits of the standalone track for the global muon,
+		##      since it is already embedded in the denominator
+		##      and the matching already ensures it is propagated to the numerator
+		d = d.Define("passCondition_tracking",
+				     "Probe_isMatched(TPPairs, MergedStandAloneMuon_extraIdx, Muon_standaloneExtraIdx, Muon_forTracking)")
+		# the following was equivalent but with an additional check between probe and tag, to exclude having the same inner track, it should not be necessary
+		#d = d.Define("passCondition_tracking",
+		#             "Probe_isGlobal_checkExtraIdxTagInnerTrack(TPPairs, MergedStandAloneMuon_extraIdx, Muon_standaloneExtraIdx, Muon_forTracking, Tag_inExtraIdx, Muon_innerTrackExtraIdx)")
+		d = d.Define("passCondition", "getVariables(TPPairs, passCondition_tracking, 2)")
+		d = d.Define("failCondition", "!passCondition")
 
-        d = d.Define("TPmass_fail",    "TPmass[failCondition]")
-        d = d.Define("Probe_pt_fail",  "Probe_pt[failCondition]")
-        d = d.Define("Probe_eta_fail", "Probe_eta[failCondition]")
-        
-        print("Making histograms for tracking step")
-        makeAndSaveHistograms(d, histo_name, "Tracking", binning_mass, binning_pt, binning_eta)
+		# use the minimum pt of the standalone muon used above to define the range, also a larger upper edge because the pt resolution of standalone muons is bad
+		#binning_pt = array('d',[15., 80.]) # try also 24,65
+		#binning_pt = array('d',[15., 30., 45., 60., 80.])
+		#binning_pt = array('d',[15., 25., 35., 45., 55., 65., 80.])
+		#binning_pt = array('d',[24., 65.])
+		binning_pt = array('d',[24., 35., 45., 55., 65.])
+		#binning_pt = array('d',[(15.0 + i*1.0) for i in range(66) ])
 
-        # save also the mass for passing probes computed with standalone variables
-        # needed when making MC template for failing probes using all probes, since the mass should be consistently measured for both cases
-        # do it also for data in case we want to check the difference in the efficiencies
-        d = d.Define("TPmassFromSA_pass", "TPmass[passCondition]")
-        makeAndSaveOneHist(d, f"{histo_name}_alt", "Tracking (mass from SA muons)",
-                           binning_mass, binning_pt, binning_eta,
-                           massVar="TPmassFromSA", isPass=True)
+		# Here we are using the muon variables to calulate the mass for the passing probes for tracking efficiency
+		## However the TPPairs were made using indices from MergedStandAloneMuon_XX collections, which are not necessarily valid for Muon_XX
+		## Thus, for each passing MergedStandAloneMuon I store the pt,eta,phi of the corresponding Muon (which exists as long as we use the MergedStandAloneMuon indices from TPPairs_pass)
+		d = d.Define("TPPairs_pass", "TPPairs[passCondition]")
+		d = d.Define("MergedStandaloneMuon_MuonIdx", "getMergedStandAloneMuon_MuonIdx(MergedStandAloneMuon_extraIdx, Muon_standaloneExtraIdx)")
+		d = d.Define("MergedStandaloneMuon_MuonPt",  "getMergedStandAloneMuon_matchedObjectVar(MergedStandaloneMuon_MuonIdx, Muon_pt)")
+		d = d.Define("MergedStandaloneMuon_MuonEta", "getMergedStandAloneMuon_matchedObjectVar(MergedStandaloneMuon_MuonIdx, Muon_eta)")
+		d = d.Define("MergedStandaloneMuon_MuonPhi", "getMergedStandAloneMuon_matchedObjectVar(MergedStandaloneMuon_MuonIdx, Muon_phi)")
+
+		d = d.Define("TPmass_pass",    "getTPmass(TPPairs_pass, Tag_pt, Tag_eta, Tag_phi, MergedStandaloneMuon_MuonPt, MergedStandaloneMuon_MuonEta, MergedStandaloneMuon_MuonPhi)")
+		d = d.Define("Probe_pt_pass",  "Probe_pt[passCondition]")
+		d = d.Define("Probe_eta_pass", "Probe_eta[passCondition]")
+
+		d = d.Define("TPmass_fail",    "TPmass[failCondition]")
+		d = d.Define("Probe_pt_fail",  "Probe_pt[failCondition]")
+		d = d.Define("Probe_eta_fail", "Probe_eta[failCondition]")
+
+		####
+		d = d.Define("dR_SA_gen", "coll1coll2DR(Probe_eta, Probe_phi, GenMuonBare_eta, GenMuonBare_phi)")
+		d = d.Define("dR_SA_gen_fail", "dR_SA_gen[failCondition]")
+		####
+		print("Making histograms for tracking step")
+		makeAndSaveHistograms(d, histo_name, "Tracking", binning_mass, binning_pt, binning_eta)
+
+		# save also the mass for passing probes computed with standalone variables
+		# needed when making MC template for failing probes using all probes, since the mass should be consistently measured for both cases
+		# do it also for data in case we want to check the difference in the efficiencies
+		d = d.Define("TPmassFromSA_pass", "TPmass[passCondition]")
+		makeAndSaveOneHist(d, f"{histo_name}_alt", "Tracking (mass from SA muons)",
+				           binning_mass, binning_pt, binning_eta,
+				           massVar="TPmassFromSA", isPass=True)
  
         
-    else:
-        d = d.Define("goodmuon","goodmuonglobal(goodgeneta,goodgenphi,Muon_pt,Muon_eta,Muon_phi,Muon_isGlobal,Muon_standalonePt,Muon_standaloneEta,Muon_standalonePhi)").Define("newweight","weight*goodmuon")
+	else:
+		d = d.Define("goodmuon","goodmuonglobal(goodgeneta,goodgenphi,Muon_pt,Muon_eta,Muon_phi,Muon_isGlobal,Muon_standalonePt,Muon_standaloneEta,Muon_standalonePhi)").Define("newweight","weight*goodmuon")
 
-        model_pass_reco = ROOT.RDF.TH2DModel("Pass","",len(binning_eta)-1,binning_eta,len(binning_pt)-1,binning_pt)
-        model_norm_reco = ROOT.RDF.TH2DModel("Norm","",len(binning_eta)-1,binning_eta,len(binning_pt)-1,binning_pt)
+		model_pass_reco = ROOT.RDF.TH2DModel("Pass","",len(binning_eta)-1,binning_eta,len(binning_pt)-1,binning_pt)
+		model_norm_reco = ROOT.RDF.TH2DModel("Norm","",len(binning_eta)-1,binning_eta,len(binning_pt)-1,binning_pt)
 
-        pass_histogram_reco = d.Histo2D(model_pass_reco,"goodgeneta","goodgenpt","newweight")
-        pass_histogram_norm = d.Histo2D(model_norm_reco,"goodgeneta","goodgenpt","weight")
+		pass_histogram_reco = d.Histo2D(model_pass_reco,"goodgeneta","goodgenpt","newweight")
+		pass_histogram_norm = d.Histo2D(model_norm_reco,"goodgeneta","goodgenpt","weight")
 
-        pass_histogram_reco.Write()
-        pass_histogram_norm.Write()
+		pass_histogram_reco.Write()
+		pass_histogram_norm.Write()
 
 ## Muons for all other efficiency step except veto
 elif args.efficiency != 7:
-    if (args.isData!=1) and (args.isBkg!=1):
-        d = d.Define("GenMatchedIdx","GenMatchedIdx(GenMuonBare_eta, GenMuonBare_phi, Muon_eta, Muon_phi)")
+    if not (args.noGenMatching or args.isData==1) or args.reverseGenMatching:
+        genMatchCut = 0.3 if not args.reverseGenMatching else -0.3
+        d = d.Define("GenMatchedIdx","GenMatchedIdx(GenMuonBare_eta, GenMuonBare_phi, Muon_eta, Muon_phi, genMatchCut)")
 
     chargeCut = ""
     if args.charge:
         sign= ">" if args.charge > 0 else "<"
         chargeCut = f" && Muon_charge {sign} 0"
-        
+
     d = d.Define("globalMuon_standaloneNvalidHits", "getGlobalMuon_MergedStandAloneMuonVar(Muon_standaloneExtraIdx, MergedStandAloneMuon_extraIdx, MergedStandAloneMuon_numberOfValidHits)")
     d = d.Define("BasicProbe_Muons", f"Muon_isGlobal && Muon_pt > 24 && Muon_standalonePt > 15 && abs(Muon_eta) < 2.4 && selfDeltaR(Muon_eta, Muon_phi, Muon_standaloneEta, Muon_standalonePhi) < 0.3 && Muon_highPurity && isGenMatchedMuon {chargeCut} && globalMuon_standaloneNvalidHits >= {minStandaloneNumberOfValidHits}")
     # add MergedStandAloneMuon_numberOfValidHits > 0 matching the global muon to its standalone one 

--- a/Steve.py
+++ b/Steve.py
@@ -325,12 +325,12 @@ else:
 if args.year == "2016":
     d = d.Define("isTriggeredMuon","hasTriggerMatch(Muon_eta, Muon_phi, TrigObj_id, TrigObj_filterBits, TrigObj_eta, TrigObj_phi)")
 else:
-    d =d.Define("isTriggeredMuon","hasTriggerMatch2018(Muon_eta, Muon_phi, TrigObj_id, TrigObj_filterBits, TrigObj_eta, TrigObj_phi)")
+    d = d.Define("isTriggeredMuon","hasTriggerMatch2018(Muon_eta, Muon_phi, TrigObj_id, TrigObj_filterBits, TrigObj_eta, TrigObj_phi)")
 
-if(args.isData == 1):
+if (args.isData==1) or (args.isBkg==1):
     d = d.Define("isGenMatchedMuon","createTrues(nMuon)")
-else: 
-    d = d.Define("GenMuonBare", "GenPart_status == 1 && (GenPart_statusFlags & 1 || GenPart_statusFlags & (5<<1)) && abs(GenPart_pdgId) == 13")
+else:
+    d = d.Define("GenMuonBare", "GenPart_status == 1 && (GenPart_statusFlags & 1 || (GenPart_statusFlags & (5<<1))) && abs(GenPart_pdgId) == 13")
     d = d.Define("GenMuonBare_pt", "GenPart_pt[GenMuonBare]")
     d = d.Define("GenMuonBare_eta", "GenPart_eta[GenMuonBare]")
     d = d.Define("GenMuonBare_phi", "GenPart_phi[GenMuonBare]")
@@ -376,11 +376,11 @@ f_out = ROOT.TFile(args.output_file, "RECREATE")
 if(args.efficiency == 1):
     if not (args.genLevelEfficiency):
 
-        if(args.isData == 1):
+        if (args.isData==1) or (args.isBkg==1):
             d = d.Define("isGenMatchedTrack","createTrues(nTrack)")
         else:
-            d = d.Define("isGenMatchedTrack", "hasGenMatch(  GenMuonBare_eta, GenMuonBare_phi, Track_eta, Track_phi)")
-            d = d.Define("GenMatchedIdx",     "GenMatchedIdx(GenMuonBare_eta, GenMuonBare_phi, Track_eta, Track_phi)")
+            d = d.Define("isGenMatchedTrack", "hasGenMatch(GenMuonBare_eta, GenMuonBare_phi, Track_eta, Track_phi)")
+            d = d.Define("GenMatchedIdx", "GenMatchedIdx(GenMuonBare_eta, GenMuonBare_phi, Track_eta, Track_phi)")
 
         chargeCut = ""
         if args.charge:
@@ -446,8 +446,8 @@ if(args.efficiency == 1):
 #Global|MergedStandAloneMuon ("tracking" efficiency)
 elif (args.efficiency == 2):
     if not (args.genLevelEfficiency):
-        if(args.isData == 1):
-            d = d.Define("isGenMatchedMergedStandMuon","createTrues(nMergedStandAloneMuon)")
+        if (args.isData==1) or (args.isBkg==1):
+            d = d.Define("isGenMatchedMergedStandMuon", "createTrues(nMergedStandAloneMuon)")
         else:
             d = d.Define("isGenMatchedMergedStandMuon","hasGenMatch(GenMuonBare_eta, GenMuonBare_phi, MergedStandAloneMuon_eta, MergedStandAloneMuon_phi, 0.3)")
             d = d.Define("GenMatchedIdx","GenMatchedIdx(GenMuonBare_eta, GenMuonBare_phi, MergedStandAloneMuon_eta, MergedStandAloneMuon_phi, 0.3)")
@@ -540,7 +540,7 @@ elif (args.efficiency == 2):
 
 ## Muons for all other efficiency step except veto
 elif args.efficiency != 7:
-    if(args.isData != 1):
+    if (args.isData!=1) and (args.isBkg!=1):
         d = d.Define("GenMatchedIdx","GenMatchedIdx(GenMuonBare_eta, GenMuonBare_phi, Muon_eta, Muon_phi)")
 
     chargeCut = ""
@@ -902,7 +902,7 @@ else:
     #d = d.Define("BasicProbe_Muons", f"Muon_pt > 10 && abs(Muon_eta) < 2.4 && (Muon_isGlobal || Muon_isTracker) && isGenMatchedMuon {chargeCut}")
     #
     # use tracks for all probes rather than muons
-    if(args.isData == 1):
+    if (args.isData==1) or (args.isBkg==1):
         d = d.Define("isGenMatchedTrack","createTrues(nTrack)")
     else:
         d = d.Define("isGenMatchedTrack", "hasGenMatch(  GenMuonBare_eta, GenMuonBare_phi, Track_eta, Track_phi)")

--- a/Steve.py
+++ b/Steve.py
@@ -57,13 +57,6 @@ def makeAndSaveHistograms(d, histo_name, histo_title, binning_mass, binning_pt, 
     makeAndSaveOneHist(d, histo_name, histo_title, binning_mass, binning_pt, binning_eta, massVar, isPass=True)
     makeAndSaveOneHist(d, histo_name, histo_title, binning_mass, binning_pt, binning_eta, massVar, isPass=False)
     
-    ######
-    model_deltaR = ROOT.RDF.TH1DModel(f"dR", f"dR(probe,gen)", 320, 0, 5.5)
-    deltaR_hist = d.Histo1D(model_deltaR, "dR_SA_gen_fail")
-    print(deltaR_hist.Integral())
-    deltaR_hist.Write()
-    ######
-    
 
 
 def make_jsonhelper(filename):
@@ -533,10 +526,6 @@ elif (args.efficiency == 2):
 		d = d.Define("Probe_pt_fail",  "Probe_pt[failCondition]")
 		d = d.Define("Probe_eta_fail", "Probe_eta[failCondition]")
 
-		####
-		d = d.Define("dR_SA_gen", "coll1coll2DR(Probe_eta, Probe_phi, GenMuonBare_eta, GenMuonBare_phi)")
-		d = d.Define("dR_SA_gen_fail", "dR_SA_gen[failCondition]")
-		####
 		print("Making histograms for tracking step")
 		makeAndSaveHistograms(d, histo_name, "Tracking", binning_mass, binning_pt, binning_eta)
 

--- a/Steve.py
+++ b/Steve.py
@@ -32,9 +32,9 @@ def makeAndSaveOneHist(d, histo_name, histo_title, binning_mass, binning_pt, bin
 
 def makeAndSaveHistograms(d, histo_name, histo_title, binning_mass, binning_pt, binning_eta, massVar="TPmass", scaleFactor=1.0):
 
-    if "dR_SA_gen" in d.GetColumnNames():
+    if "dR_probe_gen" in d.GetColumnNames():
         model_deltaR = ROOT.RDF.TH1DModel(f"dR", f"dR(probe,gen)", 320, 0, 5.5)
-        deltaR_hist = d.Histo1D(model_deltaR, "dR_SA_gen")
+        deltaR_hist = d.Histo1D(model_deltaR, "dR_probe_gen")
         print(deltaR_hist.Integral())
         deltaR_hist.Write()
 
@@ -369,14 +369,17 @@ if args.efficiency==1:
         d = d.Define("TPPairs", f"All_TPPairs[{massCut} && {ZdiffCut}]")
         d = d.Define("TPmass",  f"All_TPmass[{massCut}  && {ZdiffCut}]")
 
-        d = d.Define("Probe_pt",   "getVariables(TPPairs, Track_pt,  2)")
-        d = d.Define("Probe_eta",  "getVariables(TPPairs, Track_eta, 2)")
+        d = d.Define("Probe_pt",  "getVariables(TPPairs, Track_pt,  2)")
+        d = d.Define("Probe_eta", "getVariables(TPPairs, Track_eta, 2)")
+        d = d.Define("Probe_phi", "getVariables(TPPairs, Track_phi, 2)")
+        
         d = d.Define("passCondition", "getVariables(TPPairs, passCondition_reco, 2)")
         d = d.Define("failCondition", "!passCondition")
 
         if (args.tnpGenLevel):
-            d = d.Redefine("Probe_pt","getGenVariables(TPPairs,GenMatchedIdx,GenMuonBare_pt,2)")
-            d = d.Redefine("Probe_eta","getGenVariables(TPPairs,GenMatchedIdx,GenMuonBare_eta,2)")
+            d = d.Redefine("Probe_pt",  "getGenVariables(TPPairs, GenMatchedIdx, GenMuonBare_pt,  2)")
+            d = d.Redefine("Probe_eta", "getGenVariables(TPPairs, GenMatchedIdx, GenMuonBare_eta, 2)")
+            d = d.Redefine("Probe_phi", "getGenVariables(TPPairs, GenMatchedIdx, GenMuonBare_phi, 2)")
         
         d = d.Define("Probe_pt_pass",  "Probe_pt[passCondition]")
         d = d.Define("Probe_eta_pass", "Probe_eta[passCondition]")
@@ -386,7 +389,7 @@ if args.efficiency==1:
         d = d.Define("TPmass_fail", "TPmass[failCondition]")
 
         if not args.isData:  #saving the distribution of the dR between the gen muon and the probe, to have an a-posteriori check of the choice
-            d = d.Define("dR_SA_gen", "coll1coll2DR(Probe_eta, Probe_phi, GenMuonBare_eta, GenMuonBare_phi)")
+            d = d.Define("dR_probe_gen", "coll1coll2DR(Probe_eta, Probe_phi, GenMuonBare_eta, GenMuonBare_phi)")
 
         normFactor = args.normFactor
         scale = 1.0 if args.isData else (normFactor/weightSum.GetValue()) if args.normalizeMCsumGenWeights else normFactor
@@ -431,10 +434,12 @@ elif args.efficiency==2:
 
         d = d.Define("Probe_pt",  "getVariables(TPPairs, MergedStandAloneMuon_pt,  2)")
         d = d.Define("Probe_eta", "getVariables(TPPairs, MergedStandAloneMuon_eta, 2)")
+        d = d.Define("Probe_phi", "getVariables(TPPairs, MergedStandAloneMuon_phi, 2)")
 
         if (args.tnpGenLevel):
-            d = d.Redefine("Probe_pt","getGenVariables(TPPairs,GenMatchedIdx,GenMuonBare_pt,2)")
-            d = d.Redefine("Probe_eta","getGenVariables(TPPairs,GenMatchedIdx,GenMuonBare_eta,2)")
+            d = d.Redefine("Probe_pt",  "getGenVariables(TPPairs, GenMatchedIdx, GenMuonBare_pt,  2)")
+            d = d.Redefine("Probe_eta", "getGenVariables(TPPairs, GenMatchedIdx, GenMuonBare_eta, 2)")
+            d = d.Redefine("Probe_eta", "getGenVariables(TPPairs, GenMatchedIdx, GenMuonBare_phi, 2)")
 
         # condition for passing probe, start from Muon_XX and then add match of extraID indices between Muon and MergedStandAloneMuon
         #d = d.Define("Muon_standaloneNvalidHits", "getGlobalMuon_MergedStandAloneMuonVar(Muon_standaloneExtraIdx, MergedStandAloneMuon_extraIdx, MergedStandAloneMuon_numberOfValidHits)")
@@ -478,7 +483,7 @@ elif args.efficiency==2:
         d = d.Define("Probe_eta_fail", "Probe_eta[failCondition]")
 
         if not args.isData:  #saving the distribution of the dR between the gen muon and the probe, to have an a-posteriori check of the choice
-            d = d.Define("dR_SA_gen", "coll1coll2DR(Probe_eta, Probe_phi, GenMuonBare_eta, GenMuonBare_phi)")
+            d = d.Define("dR_probe_gen", "coll1coll2DR(Probe_eta, Probe_phi, GenMuonBare_eta, GenMuonBare_phi)")
 
         normFactor = args.normFactor
         scale = 1.0 if args.isData else (normFactor/weightSum.GetValue()) if args.normalizeMCsumGenWeights else normFactor

--- a/Steve.py
+++ b/Steve.py
@@ -53,7 +53,7 @@ def makeAndSaveHistograms(d, histo_name, histo_title, binning_mass, binning_pt, 
     
     # pass_histogram.Write()
     # fail_histogram.Write()
-
+    
     makeAndSaveOneHist(d, histo_name, histo_title, binning_mass, binning_pt, binning_eta, massVar, isPass=True)
     makeAndSaveOneHist(d, histo_name, histo_title, binning_mass, binning_pt, binning_eta, massVar, isPass=False)
     
@@ -327,7 +327,7 @@ if args.year == "2016":
 else:
     d = d.Define("isTriggeredMuon","hasTriggerMatch2018(Muon_eta, Muon_phi, TrigObj_id, TrigObj_filterBits, TrigObj_eta, TrigObj_phi)")
 
-if (args.isData==1) or (args.isBkg==1):
+if args.isData==1:
     d = d.Define("isGenMatchedMuon","createTrues(nMuon)")
 else:
     d = d.Define("GenMuonBare", "GenPart_status == 1 && (GenPart_statusFlags & 1 || (GenPart_statusFlags & (5<<1))) && abs(GenPart_pdgId) == 13")

--- a/runAll.py
+++ b/runAll.py
@@ -55,7 +55,8 @@ if __name__ == "__main__":
                         help='Output directory to store all root files')
     parser.add_argument('-d',  '--dryRun', action='store_true',
                         help='Do not execute commands, just print them')
-    parser.add_argument('-r',  '--run', default="all", type=str, choices=["data", "mc", "stand", "bkg", "Ztautau", "TTSemileptonic", "TTFullyleptonic", "ZZ", "WZ", "WW", "all"],
+    parser.add_argument('-r',  '--run', default="all", type=str, 
+                        choices=["data", "mc", "stand", "bkg", "Ztautau", "TTSemileptonic", "TTFullyleptonic", "WplusJets", "WminusJets", "ZZ", "WZ", "WW", "all"],
                         help='Choose what to run, either data or MC, or both')
     # FIXME: unless I change histogram names inside the files I can't merge different working points, I could just merge data with MC but not worth
     #parser.add_argument('-m',  '--merge', action='store_true',
@@ -108,14 +109,17 @@ if __name__ == "__main__":
         safeSystem(f"mkdir -p {outdir}", dryRun=False)
 
     inputdir_dict = {"data" : "SingleMuon/", 
-                     "mc" : "DYJetsToMuMu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/", 
+                     "mc" : "DYJetsToMuMu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/",
+                     #"mc" : "DYJetsToMuMu_H2ErratumFix_PDFExt_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/",
                      "Ztautau" : "DYJetsToTauTau_M-50_AtLeastOneEorMuDecay_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/", 
                      "TTFullyleptonic" : "TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/",
                      "TTSemileptonic" : "TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/",
+                     "WplusJets" : "WplusJetsToMuNu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/",
+                     "WminusJets" : "WminusJetsToMuNu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/",
                      "ZZ" : "ZZTo2L2Nu_TuneCP5_13TeV_powheg_pythia8/", 
                      "WZ" :"WZ_TuneCP5_13TeV-pythia8/", 
                      "WW" : "WW_TuneCP5_13TeV-pythia8/"}
-    isBkg_dict = {"data": 0, "mc": 0, "Ztautau": 1, "TTSemileptonic": 1, "TTFullyleptonic": 1, "ZZ": 1, "WZ": 1, "WW": 1}
+    isBkg_dict = {"data": 0, "mc": 0, "Ztautau": 1, "TTSemileptonic": 1, "TTFullyleptonic": 1, "WplusJets": 1, "WminusJets":1, "ZZ": 1, "WZ": 1, "WW": 1}
 
     #inputdir_data = "SingleMuon/"
     #inputdir_mc   = "DYJetsToMuMu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/"
@@ -136,6 +140,10 @@ if __name__ == "__main__":
         toRun.append("TTFullyleptonic")
     if args.run in ["all", "bkg", "TTSemileptonic"]:
         toRun.append("TTSemileptonic")
+    if args.run in ["all", "bkg", "WplusJets"]:
+        toRun.append("WplusJets")
+    if args.run in ["all", "bkg", "WminusJets"]:
+        toRun.append("WminusJets")
     if args.run in ["all", "bkg", "ZZ"]:
         toRun.append("ZZ")
     if args.run in ["all", "bkg", "WZ"]:

--- a/runAll.py
+++ b/runAll.py
@@ -47,8 +47,9 @@ workingPoints = { 1: "reco",
 
 inputdir_dict = { "data" : "SingleMuon/", 
                   "mc" : ["DYJetsToMuMu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/",
-                          "DYJetsToMuMu_H2ErratumFix_PDFExt_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/",
-                          "DYJetsToMuMu_M-10to50_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/"],
+                          "DYJetsToMuMu_H2ErratumFix_PDFExt_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/"
+                          #"DYJetsToMuMu_M-10to50_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/"
+                          ],
                   "Ztautau" : "DYJetsToTauTau_M-50_AtLeastOneEorMuDecay_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/",
                   "TTFullyleptonic" : "TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/",
                   "TTSemileptonic" : "TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/",
@@ -56,7 +57,8 @@ inputdir_dict = { "data" : "SingleMuon/",
                   "WminusJets" : "WminusJetsToMuNu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/",
                   "ZZ" : "ZZTo2L2Nu_TuneCP5_13TeV_powheg_pythia8/", 
                   "WZ" : "WZ_TuneCP5_13TeV-pythia8/", 
-                  "WW" : "WWTo2L2Nu_TuneCP5_13TeV-powheg-pythia8" #"WW_TuneCP5_13TeV-pythia8/"
+                  "WW" : "WWTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/", #"WW_TuneCP5_13TeV-pythia8/"
+                  "QCD" : "QCD_Pt-20_MuEnrichedPt15_TuneCP5_13TeV-pythia8/" 
 }
 #inputdir_data = "SingleMuon/"
 #inputdir_mc   = "DYJetsToMuMu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/"
@@ -66,7 +68,7 @@ inputdir_dict = { "data" : "SingleMuon/",
 #inputdir_WZ = "WZ_TuneCP5_13TeV-pythia8/"
 #inputdir_WW = "WW_TuneCP5_13TeV-pythia8/"   
 
-isBkg_dict = {"data": 0, "mc": 0, "Ztautau": 1, "TTSemileptonic": 1, "TTFullyleptonic": 1, "WplusJets": 1, "WminusJets":1, "ZZ": 1, "WZ": 1, "WW": 1}
+isBkg_dict = {"data": 0, "mc": 0, "Ztautau": 1, "TTSemileptonic": 1, "TTFullyleptonic": 1, "WplusJets": 1, "WminusJets":1, "ZZ": 1, "WZ": 1, "WW": 1, "QCD": 1}
 
 
 # -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -85,7 +87,7 @@ if __name__ == "__main__":
 
     parser.add_argument('-r',  '--run', help='Choose what to run, either data or MC, or both',
     					default=["all"], nargs="*",
-    					choices=["data", "mc", "stand", "bkg", "Ztautau", "TTSemileptonic", "TTFullyleptonic", "WplusJets", "WminusJets", "ZZ", "WZ", "WW", "all"])
+    					choices=["data", "mc", "stand", "bkg", "Ztautau", "TTSemileptonic", "TTFullyleptonic", "WplusJets", "WminusJets", "ZZ", "WZ", "WW", "QCD", "all"])
                     
     # FIXME: unless I change histogram names inside the files I can't merge different working points, I could just merge data with MC but not worth
     #parser.add_argument('-m',  '--merge', action='store_true', help='Merge root files in a new one')
@@ -162,6 +164,7 @@ if __name__ == "__main__":
         if dataset_run in ["all", "bkg", "ZZ"]: toRun.append("ZZ")
         if dataset_run in ["all", "bkg", "WZ"]: toRun.append("WZ")
         if dataset_run in ["all", "bkg", "WW"]: toRun.append("WW")
+        if dataset_run in ["all", "bkg", "QCD"]: toRun.append("QCD")
    
    
     outfiles = [] # store names of output files so to merge them if needed

--- a/runAll.py
+++ b/runAll.py
@@ -45,118 +45,133 @@ workingPoints = { 1: "reco",
                   7: "veto"
 }
 
+inputdir_dict = { "data" : "SingleMuon/", 
+                  "mc" : "DYJetsToMuMu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/",
+                  #"mc" : "DYJetsToMuMu_H2ErratumFix_PDFExt_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/",
+                  "Ztautau" : "DYJetsToTauTau_M-50_AtLeastOneEorMuDecay_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/", 
+                  "TTFullyleptonic" : "TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/",
+                  "TTSemileptonic" : "TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/",
+                  "WplusJets" : "WplusJetsToMuNu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/",
+                  "WminusJets" : "WminusJetsToMuNu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/",
+                  "ZZ" : "ZZTo2L2Nu_TuneCP5_13TeV_powheg_pythia8/", 
+                  "WZ" :"WZ_TuneCP5_13TeV-pythia8/", 
+                  "WW" : "WW_TuneCP5_13TeV-pythia8/"
+}
+#inputdir_data = "SingleMuon/"
+#inputdir_mc   = "DYJetsToMuMu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/"
+#inputdir_Ztautau = "DYJetsToTauTau_M-50_AtLeastOneEorMuDecay_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/"
+#inputdir_TTSemileptonic = "TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/"
+#inputdir_ZZ = "ZZTo2L2Nu_TuneCP5_13TeV_powheg_pythia8/"
+#inputdir_WZ = "WZ_TuneCP5_13TeV-pythia8/"
+#inputdir_WW = "WW_TuneCP5_13TeV-pythia8/"   
+
+isBkg_dict = {"data": 0, "mc": 0, "Ztautau": 1, "TTSemileptonic": 1, "TTFullyleptonic": 1, "WplusJets": 1, "WminusJets":1, "ZZ": 1, "WZ": 1, "WW": 1}
+
+
+# -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     
 if __name__ == "__main__":    
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('-i','--indir',  default=None, type=str, required=True,
-                        help='Input directory with the root files inside (common path for data and MC)')
-    parser.add_argument('-o','--outdir', default=None, type=str, required=True,
-                        help='Output directory to store all root files')
-    parser.add_argument('-d',  '--dryRun', action='store_true',
-                        help='Do not execute commands, just print them')
-    parser.add_argument('-r',  '--run', default="all", type=str, 
-                        choices=["data", "mc", "stand", "bkg", "Ztautau", "TTSemileptonic", "TTFullyleptonic", "WplusJets", "WminusJets", "ZZ", "WZ", "WW", "all"],
-                        help='Choose what to run, either data or MC, or both')
-    # FIXME: unless I change histogram names inside the files I can't merge different working points, I could just merge data with MC but not worth
-    #parser.add_argument('-m',  '--merge', action='store_true',
-    #                    help='Merge root files in a new one')
-    parser.add_argument('-nw', '--noVertexPileupWeight', action='store_true',
-                        help='Do not use weights for vertex z position')
-    parser.add_argument("-nos", "--noOppositeCharge", action="store_true",
-                        help="Don't require opposite charges between tag and probe (including tracking, unless also using --noOppositeChargeTracking)")
-    parser.add_argument(        "--noOppositeChargeTracking", action="store_true",
-                                help="Don't require opposite charges between tag and probe for tracking")
-    parser.add_argument("-sc", "--SameCharge", action="store_true", help="Require the TP Pair to have same sign (fo bkg study)",
-                        default=False)
-    parser.add_argument('-s','--steps', default=None, nargs='*', type=int, choices=list(workingPoints.keys()),
-                        help='Default runs all working points, but can choose only some if needed')
-    parser.add_argument('-x','--exclude', default=None, nargs='*', type=int, choices=list(workingPoints.keys()),
-                        help='Default runs all working points, but can choose to skip some if needed')
-    parser.add_argument('-wpc','---workinPointsByCharge', default=["trigger"], nargs='*', type=str, choices=list(workingPoints.values()),
-                        help='These steps will be made charge dependent')
-    parser.add_argument("-trk", "--trackerMuons", action="store_true",
-                        help="Use tracker muons and a different executable")
-    parser.add_argument("-p","--eventParity", help="Select events with given parity for statistical tests, -1/1 for odd/even events, 0 for all (default)",
-                        type=int, nargs='+', default=[0], choices=[-1, 0, 1])
-    parser.add_argument("-tpt","--tagPt", help="Minimum pt to select tag muons",
-                        type=float, default=25.)
-    parser.add_argument("-tiso","--tagIso", help="Isolation threshold to select tag muons",
-                        type=float, default=0.15)
-    parser.add_argument(        "--standaloneValidHits", help="Minimum number of valid hits for the standalone track (>= this value)",
-                        type=int, default=1)
-    #parser.add_argument('-exe', '--executable', default="Steve.py", type=str, choices=["Steve.py", "Steve_tracker.py"],
-    #                    help='Choose script to run')
+    
+    parser.add_argument('-i','--indir', help='Input directory with the root files inside (common path for data and MC)',
+                        type=str, default=None, required=True)
 
-    parser.add_argument("-y","--year", help="run year 2016, 2017, 2018",
-                    type=str,default="2016")
-    parser.add_argument("-iso","--isoDefinition",help="Choose between the old and new isolation definition, 0 is old, 1 is new", default=1, type=int, choices = [0,1])
+    parser.add_argument('-o','--outdir', help='Output directory to store all root files',
+    					type=str, default=None, required=True)
+
+    parser.add_argument('-d',  '--dryRun', action='store_true', help='Do not execute commands, just print them')
+
+    parser.add_argument('-r',  '--run', help='Choose what to run, either data or MC, or both',
+    					type=str, default="all", choices=["data", "mc", "stand", "bkg", "Ztautau", "TTSemileptonic", "TTFullyleptonic", "WplusJets", "WminusJets", "ZZ", "WZ", "WW", "all"])
+                    
+    # FIXME: unless I change histogram names inside the files I can't merge different working points, I could just merge data with MC but not worth
+    #parser.add_argument('-m',  '--merge', action='store_true', help='Merge root files in a new one')
+   
+    parser.add_argument('-nw', '--noVertexPileupWeight', action='store_true', help='Do not use weights for vertex z position')
+    
+    parser.add_argument('-ngm', '--noGenMatching', action='store_true', help='Do not apply gen-matching for the probe (for non prompt bkg study)')
+    
+    parser.add_argument(        '--reverseGenMatching', action='store_true', help='Reverse the gen-matching condition for the probe (for non prompt contributions on Zmumu sample)')
+    
+    parser.add_argument("-nos", "--noOppositeCharge", action="store_true", help="Don't require opposite charges between tag and probe (including tracking, unless also using --noOppositeChargeTracking)")
+    
+    parser.add_argument(        "--noOppositeChargeTracking", action="store_true", help="Don't require opposite charges between tag and probe for tracking")
+    
+    parser.add_argument("-sc", "--SameCharge", action="store_true", help="Require the TP Pair to have same sign (fo bkg study)")
+    
+    parser.add_argument('-s', '--steps', help='Default runs all working points, but can choose only some if needed',
+    					type=int, default=None, nargs='*', choices=list(workingPoints.keys()))
+
+    parser.add_argument('-x','--exclude', help='Default runs all working points, but can choose to skip some if needed',
+    					type=int, default=None, nargs='*', choices=list(workingPoints.keys()))
+    					
+    parser.add_argument('-wpc','---workinPointsByCharge', help='These steps will be made charge dependent',
+    					type=str, default=["trigger"], nargs='*', choices=list(workingPoints.values()))
+    					
+    parser.add_argument("-trk", "--trackerMuons", action="store_true", help="Use tracker muons and a different executable")
+    
+    parser.add_argument("-p", "--eventParity", help="Select events with given parity for statistical tests, -1/1 for odd/even events, 0 for all (default)",
+                        type=int, default=[0], nargs='+', choices=[-1, 0, 1])
+              
+    parser.add_argument("-tpt", "--tagPt", help="Minimum pt to select tag muons",
+                        type=float, default=25.)
+                        
+    parser.add_argument("-tiso", "--tagIso", help="Isolation threshold to select tag muons",
+                        type=float, default=0.15)
+                        
+    parser.add_argument(		"--standaloneValidHits", help="Minimum number of valid hits for the standalone track (>= this value)",
+                        type=int, default=1)
+                        
+    # parser.add_argument('-exe', '--executable', help='Choose script to run',
+    # 					  type=str, default="Steve.py", choices=["Steve.py", "Steve_tracker.py"])
+
+    parser.add_argument("-y", "--year", help="run year 2016, 2017, 2018",
+                    	type=str, default="2016")
+                    	
+    parser.add_argument("-iso", "--isoDefinition", help="Choose between the old and new isolation definition, 0 is old, 1 is new", 
+    					type=int, default=1, choices = [0,1])
 
 
     args = parser.parse_args()
 
     outdir = args.outdir
-    if not outdir.endswith("/"):
-        outdir += "/"
+    if not outdir.endswith("/"): outdir += "/"
+    
     indir = args.indir
-    if not indir.endswith("/"):
-        indir += "/"
+    if not indir.endswith("/"):  indir += "/"
+
 
     executable = "Steve_tracker.py" if args.trackerMuons else "Steve.py"
         
     if not os.path.exists(outdir):
         print(f"Creating folder {outdir}")
         safeSystem(f"mkdir -p {outdir}", dryRun=False)
-
-    inputdir_dict = {"data" : "SingleMuon/", 
-                     "mc" : "DYJetsToMuMu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/",
-                     #"mc" : "DYJetsToMuMu_H2ErratumFix_PDFExt_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/",
-                     "Ztautau" : "DYJetsToTauTau_M-50_AtLeastOneEorMuDecay_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/", 
-                     "TTFullyleptonic" : "TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/",
-                     "TTSemileptonic" : "TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/",
-                     "WplusJets" : "WplusJetsToMuNu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/",
-                     "WminusJets" : "WminusJetsToMuNu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/",
-                     "ZZ" : "ZZTo2L2Nu_TuneCP5_13TeV_powheg_pythia8/", 
-                     "WZ" :"WZ_TuneCP5_13TeV-pythia8/", 
-                     "WW" : "WW_TuneCP5_13TeV-pythia8/"}
-    isBkg_dict = {"data": 0, "mc": 0, "Ztautau": 1, "TTSemileptonic": 1, "TTFullyleptonic": 1, "WplusJets": 1, "WminusJets":1, "ZZ": 1, "WZ": 1, "WW": 1}
-
-    #inputdir_data = "SingleMuon/"
-    #inputdir_mc   = "DYJetsToMuMu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/"
-    #inputdir_Ztautau = "DYJetsToTauTau_M-50_AtLeastOneEorMuDecay_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/"
-    #inputdir_TTSemileptonic = "TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/"
-    #inputdir_ZZ = "ZZTo2L2Nu_TuneCP5_13TeV_powheg_pythia8/"
-    #inputdir_WZ = "WZ_TuneCP5_13TeV-pythia8/"
-    #inputdir_WW = "WW_TuneCP5_13TeV-pythia8/"   
     
     toRun = []
-    if args.run in ["all", "data","stand"]:
-        toRun.append("data")
-    if args.run in ["all", "mc", "stand"]:
-        toRun.append("mc")
-    if args.run in ["all", "bkg", "Ztautau"]:
-        toRun.append("Ztautau")
-    if args.run in ["all", "bkg", "TTFullyleptonic"]:
-        toRun.append("TTFullyleptonic")
-    if args.run in ["all", "bkg", "TTSemileptonic"]:
-        toRun.append("TTSemileptonic")
-    if args.run in ["all", "bkg", "WplusJets"]:
-        toRun.append("WplusJets")
-    if args.run in ["all", "bkg", "WminusJets"]:
-        toRun.append("WminusJets")
-    if args.run in ["all", "bkg", "ZZ"]:
-        toRun.append("ZZ")
-    if args.run in ["all", "bkg", "WZ"]:
-        toRun.append("WZ")
-    if args.run in ["all", "bkg", "WW"]:
-        toRun.append("WW")
+    if args.run in ["all", "data","stand"]: toRun.append("data")
+    if args.run in ["all", "mc",  "stand"]: toRun.append("mc")
+    if args.run in ["all", "bkg", "Ztautau"]: 		  toRun.append("Ztautau")
+    if args.run in ["all", "bkg", "TTFullyleptonic"]: toRun.append("TTFullyleptonic")
+    if args.run in ["all", "bkg", "TTSemileptonic"]:  toRun.append("TTSemileptonic")
+    if args.run in ["all", "bkg", "WplusJets"]:	 toRun.append("WplusJets")
+    if args.run in ["all", "bkg", "WminusJets"]: toRun.append("WminusJets")
+    if args.run in ["all", "bkg", "ZZ"]: toRun.append("ZZ")
+    if args.run in ["all", "bkg", "WZ"]: toRun.append("WZ")
+    if args.run in ["all", "bkg", "WW"]: toRun.append("WW")
    
-    
-
+   
     outfiles = [] # store names of output files so to merge them if needed
-
-    postfix = "vertexWeights{v}_oscharge{c}".format(v="0" if args.noVertexPileupWeight  else "1",
-                                                    c="0" if args.noOppositeCharge      else "1")
+    
+    sign_vw = "0" if args.noVertexPileupWeight else "1"
+    sign_gm = "0" if args.noGenMatching 	   else "1"
+    if args.reverseGenMatching: 
+    	sign_gm = "-1"
+    sign_os = "0" if args.noOppositeCharge	   else "1"
+    SS_opt = "_SS" if args.SameCharge 	       else ""
+    
+    postfix = f"vertexWeights{sign_vw}_genMatching{sign_gm}_oscharge{sign_os}{SS_opt}"
+                                                    				              
 
     commonOption = f" --tagPt {args.tagPt} --tagIso {args.tagIso} --standaloneValidHits {args.standaloneValidHits}"
 
@@ -189,10 +204,14 @@ if __name__ == "__main__":
                     cmd += commonOption
                     if args.noVertexPileupWeight:
                         cmd += " -nw"
+                    if args.noGenMatching:
+                    	cmd += " -ngm"
+                    if args.reverseGenMatching:
+                    	cmd += " --reverseGenMatching"
                     if args.noOppositeCharge:
                         cmd += " -nos"
                     if args.noOppositeChargeTracking and wp == 2:
-                        cmd += " --noOppositeChargeTracking "
+                        cmd += " --noOppositeChargeTracking"
                     if args.SameCharge:
                         cmd += " --SameCharge"
                     print("")

--- a/runAll.py
+++ b/runAll.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
                         help='Output directory to store all root files')
     parser.add_argument('-d',  '--dryRun', action='store_true',
                         help='Do not execute commands, just print them')
-    parser.add_argument('-r',  '--run', default="all", type=str, choices=["data", "mc", "stand", "bkg", "Ztautau", "TTSemileptonic", "ZZ", "WZ", "WW", "all"],
+    parser.add_argument('-r',  '--run', default="all", type=str, choices=["data", "mc", "stand", "bkg", "Ztautau", "TTSemileptonic", "TTFullyleptonic", "ZZ", "WZ", "WW", "all"],
                         help='Choose what to run, either data or MC, or both')
     # FIXME: unless I change histogram names inside the files I can't merge different working points, I could just merge data with MC but not worth
     #parser.add_argument('-m',  '--merge', action='store_true',
@@ -72,7 +72,7 @@ if __name__ == "__main__":
                         help='Default runs all working points, but can choose only some if needed')
     parser.add_argument('-x','--exclude', default=None, nargs='*', type=int, choices=list(workingPoints.keys()),
                         help='Default runs all working points, but can choose to skip some if needed')
-    parser.add_argument('-wpc','--workinPointsByCharge', default=["trigger"], nargs='*', type=str, choices=list(workingPoints.values()),
+    parser.add_argument('-wpc','---workinPointsByCharge', default=["trigger"], nargs='*', type=str, choices=list(workingPoints.values()),
                         help='These steps will be made charge dependent')
     parser.add_argument("-trk", "--trackerMuons", action="store_true",
                         help="Use tracker muons and a different executable")
@@ -107,8 +107,15 @@ if __name__ == "__main__":
         print(f"Creating folder {outdir}")
         safeSystem(f"mkdir -p {outdir}", dryRun=False)
 
-    inputdir_dict = {"data":"SingleMuon/", "mc":"DYJetsToMuMu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/", "Ztautau":"DYJetsToTauTau_M-50_AtLeastOneEorMuDecay_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/", "TTSemileptonic":"TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/", "ZZ": "ZZTo2L2Nu_TuneCP5_13TeV_powheg_pythia8/", "WZ":"WZ_TuneCP5_13TeV-pythia8/", "WW": "WW_TuneCP5_13TeV-pythia8/"}
-    isBkg_dict = {"data": 0, "mc": 0, "Ztautau": 1, "TTSemileptonic": 1, "ZZ": 1, "WZ": 1, "WW": 1}
+    inputdir_dict = {"data" : "SingleMuon/", 
+                     "mc" : "DYJetsToMuMu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/", 
+                     "Ztautau" : "DYJetsToTauTau_M-50_AtLeastOneEorMuDecay_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/", 
+                     "TTFullyleptonic" : "TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/",
+                     "TTSemileptonic" : "TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/",
+                     "ZZ" : "ZZTo2L2Nu_TuneCP5_13TeV_powheg_pythia8/", 
+                     "WZ" :"WZ_TuneCP5_13TeV-pythia8/", 
+                     "WW" : "WW_TuneCP5_13TeV-pythia8/"}
+    isBkg_dict = {"data": 0, "mc": 0, "Ztautau": 1, "TTSemileptonic": 1, "TTFullyleptonic": 1, "ZZ": 1, "WZ": 1, "WW": 1}
 
     #inputdir_data = "SingleMuon/"
     #inputdir_mc   = "DYJetsToMuMu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/"
@@ -125,6 +132,8 @@ if __name__ == "__main__":
         toRun.append("mc")
     if args.run in ["all", "bkg", "Ztautau"]:
         toRun.append("Ztautau")
+    if args.run in ["all", "bkg", "TTFullyleptonic"]:
+        toRun.append("TTFullyleptonic")
     if args.run in ["all", "bkg", "TTSemileptonic"]:
         toRun.append("TTSemileptonic")
     if args.run in ["all", "bkg", "ZZ"]:

--- a/runAll.py
+++ b/runAll.py
@@ -81,38 +81,9 @@ def common_parser():
     parser.add_argument("--standaloneMinPt", help="Minimum value for the standalone muon pt cut",
                         type=float, default=15)
 
-    
+
     return parser
-        
-                  7: "veto"
-}
 
-inputdir_dict = { "data" : "SingleMuon/", 
-                  "mc" : ["DYJetsToMuMu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/",
-                          "DYJetsToMuMu_H2ErratumFix_PDFExt_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/",
-                          "DYJetsToMuMu_M-10to50_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/"],
-                  "Ztautau" : "DYJetsToTauTau_M-50_AtLeastOneEorMuDecay_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/",
-                  "TTFullyleptonic" : "TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/",
-                  "TTSemileptonic" : "TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/",
-                  "WplusJets" : "WplusJetsToMuNu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/",
-                  "WminusJets" : "WminusJetsToMuNu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/",
-                  "ZZ" : "ZZTo2L2Nu_TuneCP5_13TeV_powheg_pythia8/", 
-                  "WZ" : "WZ_TuneCP5_13TeV-pythia8/", 
-                  "WW" : "WWTo2L2Nu_TuneCP5_13TeV-powheg-pythia8" #"WW_TuneCP5_13TeV-pythia8/"
-}
-#inputdir_data = "SingleMuon/"
-#inputdir_mc   = "DYJetsToMuMu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/"
-#inputdir_Ztautau = "DYJetsToTauTau_M-50_AtLeastOneEorMuDecay_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/"
-#inputdir_TTSemileptonic = "TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/"
-#inputdir_ZZ = "ZZTo2L2Nu_TuneCP5_13TeV_powheg_pythia8/"
-#inputdir_WZ = "WZ_TuneCP5_13TeV-pythia8/"
-#inputdir_WW = "WW_TuneCP5_13TeV-pythia8/"   
-
-isBkg_dict = {"data": 0, "mc": 0, "Ztautau": 1, "TTSemileptonic": 1, "TTFullyleptonic": 1, "WplusJets": 1, "WminusJets":1, "ZZ": 1, "WZ": 1, "WW": 1}
-
-
-# -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    
 if __name__ == "__main__":    
 
     lumiDict = {"2016" : 16.8, # only postVFP
@@ -168,20 +139,6 @@ if __name__ == "__main__":
                         help='Do not execute commands, just print them')
     parser.add_argument('-r',  '--run', default="all", type=str, choices=allValidProcsAndSpecial,
                         help='Choose what to run, either data or MC, or both')
-    parser = argparse.ArgumentParser()
-    
-    parser.add_argument('-i','--indir', help='Input directory with the root files inside (common path for data and MC)',
-                        type=str, default=None, required=True)
-
-    parser.add_argument('-o','--outdir', help='Output directory to store all root files',
-    					type=str, default=None, required=True)
-
-    parser.add_argument('-d',  '--dryRun', action='store_true', help='Do not execute commands, just print them')
-
-    parser.add_argument('-r',  '--run', help='Choose what to run, either data or MC, or both',
-    					default=["all"], nargs="*",
-    					choices=["data", "mc", "stand", "bkg", "Ztautau", "TTSemileptonic", "TTFullyleptonic", "WplusJets", "WminusJets", "ZZ", "WZ", "WW", "all"])
-                    
     # FIXME: unless I change histogram names inside the files I can't merge different working points, I could just merge data with MC but not worth
     #parser.add_argument('-m',  '--merge', action='store_true',
     #                    help='Merge root files in a new one')
@@ -197,53 +154,6 @@ if __name__ == "__main__":
                         type=int, nargs='+', default=[0], choices=[-1, 0, 1])
     #parser.add_argument('-exe', '--executable', default="Steve.py", type=str, choices=["Steve.py", "Steve_tracker.py"],
     #                    help='Choose script to run')
-    #parser.add_argument('-m',  '--merge', action='store_true', help='Merge root files in a new one')
-   
-    parser.add_argument('-nw', '--noVertexPileupWeight', action='store_true', help='Do not use weights for vertex z position')
-    
-    parser.add_argument('-ngm', '--noGenMatching', action='store_true', help='Do not apply gen-matching for the probe (for non prompt bkg study)')
-    
-    parser.add_argument(        '--reverseGenMatching', action='store_true', help='Reverse the gen-matching condition for the probe (for non prompt contributions on Zmumu sample)')
-    
-    parser.add_argument("-nos", "--noOppositeCharge", action="store_true", help="Don't require opposite charges between tag and probe (including tracking, unless also using --noOppositeChargeTracking)")
-    
-    parser.add_argument(        "--noOppositeChargeTracking", action="store_true", help="Don't require opposite charges between tag and probe for tracking")
-    
-    parser.add_argument("-sc", "--SameCharge", action="store_true", help="Require the TP Pair to have same sign (fo bkg study)")
-    
-    parser.add_argument('-s', '--steps', help='Default runs all working points, but can choose only some if needed',
-    					type=int, default=None, nargs='*', choices=list(workingPoints.keys()))
-
-    parser.add_argument('-x','--exclude', help='Default runs all working points, but can choose to skip some if needed',
-    					type=int, default=None, nargs='*', choices=list(workingPoints.keys()))
-    					
-    parser.add_argument('-wpc','---workinPointsByCharge', help='These steps will be made charge dependent',
-    					type=str, default=["trigger"], nargs='*', choices=list(workingPoints.values()))
-    					
-    parser.add_argument("-trk", "--trackerMuons", action="store_true", help="Use tracker muons and a different executable")
-    
-    parser.add_argument("-p", "--eventParity", help="Select events with given parity for statistical tests, -1/1 for odd/even events, 0 for all (default)",
-                        type=int, default=[0], nargs='+', choices=[-1, 0, 1])
-              
-    parser.add_argument("-tpt", "--tagPt", help="Minimum pt to select tag muons",
-                        type=float, default=25.)
-                        
-    parser.add_argument("-tiso", "--tagIso", help="Isolation threshold to select tag muons",
-                        type=float, default=0.15)
-                        
-    parser.add_argument(		"--standaloneValidHits", help="Minimum number of valid hits for the standalone track (>= this value)",
-                        type=int, default=1)
-                        
-    # parser.add_argument('-exe', '--executable', help='Choose script to run',
-    # 					  type=str, default="Steve.py", choices=["Steve.py", "Steve_tracker.py"])
-
-    parser.add_argument("-y", "--year", help="run year 2016, 2017, 2018",
-                    	type=str, default="2016")
-                    	
-    parser.add_argument("-iso", "--isoDefinition", help="Choose between the old and new isolation definition, 0 is old, 1 is new", 
-    					type=int, default=1, choices = [0,1])
-
-
     args = parser.parse_args()
 
     # compare pt values within some tolerance
@@ -251,11 +161,11 @@ if __name__ == "__main__":
         raise IOError(f"Inconsistent values for options --histMinPt ({args.histMinPt}) and --innerTrackMinPt ({args.innerTrackMinPt}).\nThe former must not be smaller than the latter.\n")
 
     outdir = args.outdir
-    if not outdir.endswith("/"): outdir += "/"
-    
+    if not outdir.endswith("/"):
+        outdir += "/"
     indir = args.indir
-    if not indir.endswith("/"):  indir += "/"
-
+    if not indir.endswith("/"):
+        indir += "/"
 
     executable = "Steve_tracker.py" if args.trackerMuons else "Steve.py"
 
@@ -263,25 +173,11 @@ if __name__ == "__main__":
         print(f"Creating folder {outdir}")
         safeSystem(f"mkdir -p {outdir}", dryRun=False)
 
-    
     toRun = []
     for p in allValidProcs:
-        if args.run == "all" or args.run == p or (args.run == "bgk" and inputdir_dict[p]["isBkg"]) or (args.run == "stand" and p in ["data", "mc"]):
+        if args.run == "all" or args.run == p or (args.run == "bkg" and inputdir_dict[p]["isBkg"]) or (args.run == "stand" and p in ["data", "mc"]):
             toRun.append(p)
 
-    for dataset_run in args.run:
-        if dataset_run in ["all", "data","stand"]: toRun.append("data")
-        if dataset_run in ["all", "mc",  "stand"]: toRun.append("mc")
-        if dataset_run in ["all", "bkg", "Ztautau"]: 		  toRun.append("Ztautau")
-        if dataset_run in ["all", "bkg", "TTFullyleptonic"]: toRun.append("TTFullyleptonic")
-        if dataset_run in ["all", "bkg", "TTSemileptonic"]:  toRun.append("TTSemileptonic")
-        if dataset_run in ["all", "bkg", "WplusJets"]:	 toRun.append("WplusJets")
-        if dataset_run in ["all", "bkg", "WminusJets"]: toRun.append("WminusJets")
-        if dataset_run in ["all", "bkg", "ZZ"]: toRun.append("ZZ")
-        if dataset_run in ["all", "bkg", "WZ"]: toRun.append("WZ")
-        if dataset_run in ["all", "bkg", "WW"]: toRun.append("WW")
-   
-   
     outfiles = [] # store names of output files so to merge them if needed
 
     postfix = "vertexWeights{v}".format(v="0" if args.noVertexPileupWeight else "1")
@@ -289,16 +185,6 @@ if __name__ == "__main__":
         postfix += "_sscharge"
     else:
         postfix += "_oscharge{c}".format(c="0" if args.noOppositeCharge else "1")
-    
-    sign_vw = "0" if args.noVertexPileupWeight else "1"
-    sign_gm = "0" if args.noGenMatching 	   else "1"
-    if args.reverseGenMatching: 
-    	sign_gm = "-1"
-    sign_os = "0" if args.noOppositeCharge	   else "1"
-    SS_opt = "_SS" if args.SameCharge 	       else ""
-    
-    postfix = f"vertexWeights{sign_vw}_genMatching{sign_gm}_oscharge{sign_os}{SS_opt}"
-                                                    				              
 
     commonOption = f" --tagPt {args.tagPt} --tagIso {args.tagIso} --standaloneValidHits {args.standaloneValidHits}"
 
@@ -310,10 +196,6 @@ if __name__ == "__main__":
             inpath = " ".join(["{i}{f}".format(i=indir,f=x) for x in process["path"]])
         else:
             inpath = indir + process["path"]
-        
-        input_datasets = [inputdir_dict[xrun]] if type(inputdir_dict[xrun]) is str else inputdir_dict[xrun]
-        inpaths = [indir + in_path for in_path in input_datasets]
-        
         for wp in workingPoints.keys():            
             if args.exclude and wp in args.exclude:
                 continue
@@ -333,26 +215,25 @@ if __name__ == "__main__":
                     else:
                         outfile = f"{outdir}tnp_{step}_{xrun}_{postfix}.root"                        
                     outfiles.append(outfile)
-                    
-                    inpaths_cmd = ""
-                    for inpath in inpaths: 
-                        inpaths_cmd = inpaths_cmd + inpath + " "
-                    
-                    
-                    cmd = f"python {executable} -i {inpaths_cmd} -o {outfile} -d {isdata} -b {isBkg} -e {wp} -c {ch} -p {parity} -y {args.year} -iso {args.isoDefinition}"
+                    cmd = f"python {executable} -i {inpath} -o {outfile} -e {wp} -c {ch} -p {parity} -y {args.year} -iso {args.isoDefinition}"
+                    if args.maxFiles > 0:
+                        cmd += f" --maxFiles {args.maxFiles}"
+                    if xrun == "data":
+                        cmd += " --isData"
+                    else:
+                        norm = pb2fb * lumiDict[args.year] * process["xsec"]
+                        cmd += f" --normFactor {norm}"
+                        if process["isBkg"]:
+                            cmd += " -b"
+                        if not args.normalizeMCsumGenWeights:
+                            cmd += " --noNormalizeMCsumGenWeights"
                     cmd += commonOption
                     if args.noVertexPileupWeight:
                         cmd += " -nw"
-                    if args.noGenMatching:
-                    	cmd += " -ngm"
-                    if args.reverseGenMatching:
-                    	cmd += " --reverseGenMatching"
                     if args.noOppositeCharge:
                         cmd += " -nos"
                     if wp in [2, 9] and not args.noOppositeChargeTracking:
                         cmd += " --oppositeChargeTracking "
-                    if args.noOppositeChargeTracking and wp == 2:
-                        cmd += " --noOppositeChargeTracking"
                     if args.SameCharge:
                         cmd += " --SameCharge"
                     # pt customization options

--- a/runAll.py
+++ b/runAll.py
@@ -46,16 +46,17 @@ workingPoints = { 1: "reco",
 }
 
 inputdir_dict = { "data" : "SingleMuon/", 
-                  "mc" : "DYJetsToMuMu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/",
-                  #"mc" : "DYJetsToMuMu_H2ErratumFix_PDFExt_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/",
-                  "Ztautau" : "DYJetsToTauTau_M-50_AtLeastOneEorMuDecay_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/", 
+                  "mc" : ["DYJetsToMuMu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/",
+                          "DYJetsToMuMu_H2ErratumFix_PDFExt_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/",
+                          "DYJetsToMuMu_M-10to50_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/"],
+                  "Ztautau" : "DYJetsToTauTau_M-50_AtLeastOneEorMuDecay_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/",
                   "TTFullyleptonic" : "TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/",
                   "TTSemileptonic" : "TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/",
                   "WplusJets" : "WplusJetsToMuNu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/",
                   "WminusJets" : "WminusJetsToMuNu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/",
                   "ZZ" : "ZZTo2L2Nu_TuneCP5_13TeV_powheg_pythia8/", 
-                  "WZ" :"WZ_TuneCP5_13TeV-pythia8/", 
-                  "WW" : "WW_TuneCP5_13TeV-pythia8/"
+                  "WZ" : "WZ_TuneCP5_13TeV-pythia8/", 
+                  "WW" : "WWTo2L2Nu_TuneCP5_13TeV-powheg-pythia8" #"WW_TuneCP5_13TeV-pythia8/"
 }
 #inputdir_data = "SingleMuon/"
 #inputdir_mc   = "DYJetsToMuMu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/"
@@ -83,7 +84,8 @@ if __name__ == "__main__":
     parser.add_argument('-d',  '--dryRun', action='store_true', help='Do not execute commands, just print them')
 
     parser.add_argument('-r',  '--run', help='Choose what to run, either data or MC, or both',
-    					type=str, default="all", choices=["data", "mc", "stand", "bkg", "Ztautau", "TTSemileptonic", "TTFullyleptonic", "WplusJets", "WminusJets", "ZZ", "WZ", "WW", "all"])
+    					default=["all"], nargs="*",
+    					choices=["data", "mc", "stand", "bkg", "Ztautau", "TTSemileptonic", "TTFullyleptonic", "WplusJets", "WminusJets", "ZZ", "WZ", "WW", "all"])
                     
     # FIXME: unless I change histogram names inside the files I can't merge different working points, I could just merge data with MC but not worth
     #parser.add_argument('-m',  '--merge', action='store_true', help='Merge root files in a new one')
@@ -149,16 +151,17 @@ if __name__ == "__main__":
         safeSystem(f"mkdir -p {outdir}", dryRun=False)
     
     toRun = []
-    if args.run in ["all", "data","stand"]: toRun.append("data")
-    if args.run in ["all", "mc",  "stand"]: toRun.append("mc")
-    if args.run in ["all", "bkg", "Ztautau"]: 		  toRun.append("Ztautau")
-    if args.run in ["all", "bkg", "TTFullyleptonic"]: toRun.append("TTFullyleptonic")
-    if args.run in ["all", "bkg", "TTSemileptonic"]:  toRun.append("TTSemileptonic")
-    if args.run in ["all", "bkg", "WplusJets"]:	 toRun.append("WplusJets")
-    if args.run in ["all", "bkg", "WminusJets"]: toRun.append("WminusJets")
-    if args.run in ["all", "bkg", "ZZ"]: toRun.append("ZZ")
-    if args.run in ["all", "bkg", "WZ"]: toRun.append("WZ")
-    if args.run in ["all", "bkg", "WW"]: toRun.append("WW")
+    for dataset_run in args.run:
+        if dataset_run in ["all", "data","stand"]: toRun.append("data")
+        if dataset_run in ["all", "mc",  "stand"]: toRun.append("mc")
+        if dataset_run in ["all", "bkg", "Ztautau"]: 		  toRun.append("Ztautau")
+        if dataset_run in ["all", "bkg", "TTFullyleptonic"]: toRun.append("TTFullyleptonic")
+        if dataset_run in ["all", "bkg", "TTSemileptonic"]:  toRun.append("TTSemileptonic")
+        if dataset_run in ["all", "bkg", "WplusJets"]:	 toRun.append("WplusJets")
+        if dataset_run in ["all", "bkg", "WminusJets"]: toRun.append("WminusJets")
+        if dataset_run in ["all", "bkg", "ZZ"]: toRun.append("ZZ")
+        if dataset_run in ["all", "bkg", "WZ"]: toRun.append("WZ")
+        if dataset_run in ["all", "bkg", "WW"]: toRun.append("WW")
    
    
     outfiles = [] # store names of output files so to merge them if needed
@@ -180,7 +183,10 @@ if __name__ == "__main__":
         isdata = 1 if xrun == "data" else 0
         isBkg = isBkg_dict[xrun]
         #inpath = indir + (inputdir_data if isdata else inputdir_mc)
-        inpath = indir + inputdir_dict[xrun]
+        
+        input_datasets = [inputdir_dict[xrun]] if type(inputdir_dict[xrun]) is str else inputdir_dict[xrun]
+        inpaths = [indir + in_path for in_path in input_datasets]
+        
         for wp in workingPoints.keys():            
             if args.exclude and wp in args.exclude:
                 continue
@@ -200,7 +206,13 @@ if __name__ == "__main__":
                     else:
                         outfile = f"{outdir}tnp_{step}_{xrun}_{postfix}.root"
                     outfiles.append(outfile)
-                    cmd = f"python {executable} -i {inpath} -o {outfile} -d {isdata} -b {isBkg} -e {wp} -c {ch} -p {parity} -y {args.year} -iso {args.isoDefinition}"
+                    
+                    inpaths_cmd = ""
+                    for inpath in inpaths: 
+                        inpaths_cmd = inpaths_cmd + inpath + " "
+                    
+                    
+                    cmd = f"python {executable} -i {inpaths_cmd} -o {outfile} -d {isdata} -b {isBkg} -e {wp} -c {ch} -p {parity} -y {args.year} -iso {args.isoDefinition}"
                     cmd += commonOption
                     if args.noVertexPileupWeight:
                         cmd += " -nw"

--- a/runAll.py
+++ b/runAll.py
@@ -80,6 +80,8 @@ def common_parser():
                         type=float, default=10)
     parser.add_argument("--standaloneMinPt", help="Minimum value for the standalone muon pt cut",
                         type=float, default=15)
+    parser.add_argument("--useGenMatchForBkg", action="store_true",
+                        help="Use standard gen matching cut while running on backgrounds")
 
 
     return parser
@@ -103,10 +105,10 @@ if __name__ == "__main__":
     inputdir_dict = {"data": {"path" : "SingleMuon/",
                               "isBkg": 0,
                               "xsec" : 1.0}, # dummy, just for consistency with other processes
-                     "mc": {"path" : ["DYJetsToMuMu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/", "DYJetsToMuMu_H2ErratumFix_PDFExt_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos"],
+                     "mc": {"path" : ["DYJetsToMuMu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/", "DYJetsToMuMu_H2ErratumFix_PDFExt_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/"],
                             "isBkg" : 0,
                             "xsec" : xsec_ZmmPostVFP},
-                     "DYlowMass": {"path" : ["DYJetsToMuMu_M-10to50_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos"], # "DYJetsToMuMu_M-10to50_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos_ext1"],
+                     "DYlowMass": {"path" : ["DYJetsToMuMu_M-10to50_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/"], # "DYJetsToMuMu_M-10to50_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos_ext1"],
                                    "isBkg" : 1,
                                    "xsec" : xsec_ZmmMass10to50PostVFP},
                      "Ztautau": { "path" : "DYJetsToTauTau_M-50_AtLeastOneEorMuDecay_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/",
@@ -130,12 +132,15 @@ if __name__ == "__main__":
                      "WplusJets" : {"path" : "WplusJetsToMuNu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/",
                                     "isBkg" : 1,
                                     "xsec" : xsec_WpmunuPostVFP},
-                    "WminusJets" : {"path" : "WminusJetsToMuNu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/",
-                                    "isBkg" : 1,
-                                    "xsec" : xsec_WmmunuPostVFP},
-                    "QCD": {"path" : "QCD_Pt-20_MuEnrichedPt15_TuneCP5_13TeV-pythia8/",
+                     "WminusJets" : {"path" : "WminusJetsToMuNu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/",
+                                     "isBkg" : 1,
+                                     "xsec" : xsec_WmmunuPostVFP},
+                     "Zjets" : {"path" : ["DYJetsToMuMu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/", "DYJetsToMuMu_H2ErratumFix_PDFExt_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos"],
                             "isBkg" : 1,
-                            "xsec" : 238800}
+                            "xsec" : xsec_ZmmPostVFP},
+                     "QCD": {"path" : "QCD_Pt-20_MuEnrichedPt15_TuneCP5_13TeV-pythia8/",
+                             "isBkg" : 1,
+                             "xsec" : 238800}
                     }
 
     allValidProcs = list(inputdir_dict.keys())
@@ -237,6 +242,11 @@ if __name__ == "__main__":
                         cmd += f" --normFactor {norm}"
                         if process["isBkg"]:
                             cmd += " -b"
+                            if not args.useGenMatchForBkg:
+                                gmCut_str = "-1" if xrun=="Zjets" else "0"
+                                cmd += f" --genMatchCut {gmCut_str}"
+                            else:
+                                cmd += f" --genMatchCut 1"
                         if not args.normalizeMCsumGenWeights:
                             cmd += " --noNormalizeMCsumGenWeights"
                     cmd += commonOption


### PR DESCRIPTION
Changes and improvements of this PR:
  - the "genMatchCut" option has been added to the Steve.py parser, that allow to select the type of cut to apply
  - the default option is that backgrounds are selected without genMatching 
  - for MC-based datasets, an histogram of the dR between the probe and the nearest gen-object is saved (w/o distinction pass/fail). This may be useful to check a-posteriori which genMatch cut has been applied
  - added the "Wjets", "Zjets", "TTSemileptonic" and "QCD" datasets in the dictionary of runAll.py. The dataset previously named "TTSemileptonic" is the "TTFullyleptonic" one, and its name has been changed accordingly